### PR TITLE
Consolidate memory accesses

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -34,10 +34,9 @@ static void alist_process(const acmd_callback_t abi[], unsigned int abi_size)
 {
     uint32_t inst1, inst2;
     unsigned int acmd;
-    const OSTask_t *const task = get_task();
 
-    const uint32_t *alist = dram_u32(task->data_ptr);
-    const uint32_t *const alist_end = alist + (task->data_size >> 2);
+    const uint32_t *alist = dram_u32(*dmem_u32(TASK_DATA_PTR));
+    const uint32_t *const alist_end = alist + (*dmem_u32(TASK_DATA_SIZE) >> 2);
 
     while (alist != alist_end) {
         inst1 = *(alist++);

--- a/src/hle.h
+++ b/src/hle.h
@@ -41,45 +41,33 @@
 #define S8 3
 #endif
 
+extern RSP_INFO rsp;
+
+enum {
+    TASK_TYPE               = 0xfc0,
+    TASK_FLAGS              = 0xfc4,
+    TASK_UCODE_BOOT         = 0xfc8,
+    TASK_UCODE_BOOT_SIZE    = 0xfcc,
+    TASK_UCODE              = 0xfd0,
+    TASK_UCODE_SIZE         = 0xfd4,
+    TASK_UCODE_DATA         = 0xfd8,
+    TASK_UCODE_DATA_SIZE    = 0xfdc,
+    TASK_DRAM_STACK         = 0xfe0,
+    TASK_DRAM_STACK_SIZE    = 0xfe4,
+    TASK_OUTPUT_BUFF        = 0xfe8,
+    TASK_OUTPUT_BUFF_SIZE   = 0xfec,
+    TASK_DATA_PTR           = 0xff0,
+    TASK_DATA_SIZE          = 0xff4,
+    TASK_YIELD_DATA_PTR     = 0xff8,
+    TASK_YIELD_DATA_SIZE    = 0xffc
+};
+
 static inline int16_t clamp_s16(int_fast32_t x)
 {
     x = (x < INT16_MIN) ? INT16_MIN: x;
     x = (x > INT16_MAX) ? INT16_MAX: x;
 
     return x;
-}
-
-extern RSP_INFO rsp;
-
-typedef struct {
-    unsigned int type;
-    unsigned int flags;
-
-    unsigned int ucode_boot;
-    unsigned int ucode_boot_size;
-
-    unsigned int ucode;
-    unsigned int ucode_size;
-
-    unsigned int ucode_data;
-    unsigned int ucode_data_size;
-
-    unsigned int dram_stack;
-    unsigned int dram_stack_size;
-
-    unsigned int output_buff;
-    unsigned int output_buff_size;
-
-    unsigned int data_ptr;
-    unsigned int data_size;
-
-    unsigned int yield_data_ptr;
-    unsigned int yield_data_size;
-} OSTask_t;
-
-static inline const OSTask_t *const get_task(void)
-{
-    return (OSTask_t *)(rsp.DMEM + 0xfc0);
 }
 
 void DebugMessage(int level, const char *message, ...);

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -164,11 +164,9 @@ void jpeg_decode_OB(void)
     int32_t u_dc = 0;
     int32_t v_dc = 0;
 
-    const OSTask_t *const task = get_task();
-
-    uint32_t           address          = task->data_ptr;
-    const unsigned int macroblock_count = task->data_size;
-    const int          qscale           = task->yield_data_size;
+    uint32_t           address          = *dmem_u32(TASK_DATA_PTR);
+    const unsigned int macroblock_count = *dmem_u32(TASK_DATA_SIZE);
+    const int          qscale           = *dmem_u32(TASK_YIELD_DATA_SIZE);
 
     DebugMessage(M64MSG_VERBOSE, "jpeg_decode_OB: *buffer=%x, #MB=%d, qscale=%d",
                  address,
@@ -212,19 +210,20 @@ static void jpeg_decode_std(const char *const version,
     unsigned int macroblock_size;
     /* macroblock contains at most 6 subblocks */
     int16_t macroblock[6 * SUBBLOCK_SIZE];
-    const OSTask_t *const task = get_task();
+    uint32_t data_ptr;
 
-    if (task->flags & 0x1) {
+    if (*dmem_u32(TASK_FLAGS) & 0x1) {
         DebugMessage(M64MSG_WARNING, "jpeg_decode_%s: task yielding not implemented", version);
         return;
     }
 
-    address          = *dram_u32(task->data_ptr);
-    macroblock_count = *dram_u32(task->data_ptr + 4);
-    mode             = *dram_u32(task->data_ptr + 8);
-    qtableY_ptr      = *dram_u32(task->data_ptr + 12);
-    qtableU_ptr      = *dram_u32(task->data_ptr + 16);
-    qtableV_ptr      = *dram_u32(task->data_ptr + 20);
+    data_ptr = *dmem_u32(TASK_DATA_PTR);
+    address          = *dram_u32(data_ptr);
+    macroblock_count = *dram_u32(data_ptr + 4);
+    mode             = *dram_u32(data_ptr + 8);
+    qtableY_ptr      = *dram_u32(data_ptr + 12);
+    qtableU_ptr      = *dram_u32(data_ptr + 16);
+    qtableV_ptr      = *dram_u32(data_ptr + 20);
 
     DebugMessage(M64MSG_VERBOSE, "jpeg_decode_%s: *buffer=%x, #MB=%d, mode=%d, *Qy=%x, *Qu=%x, *Qv=%x",
                  version,

--- a/src/main.c
+++ b/src/main.c
@@ -54,7 +54,7 @@
 static unsigned int sum_bytes(const unsigned char *bytes, unsigned int size);
 static void dump_binary(const char *const filename, const unsigned char *const bytes,
                         unsigned int size);
-static void dump_task(const char *const filename, const OSTask_t *const task);
+static void dump_task(const char *const filename);
 
 static void handle_unknown_task(unsigned int sum);
 static void handle_unknown_non_task(unsigned int sum);
@@ -83,7 +83,7 @@ static int l_PluginInit = 0;
  **/
 static int is_task(void)
 {
-    return (get_task()->ucode_boot_size <= 0x1000);
+    return (*dmem_u32(TASK_UCODE_BOOT_SIZE) <= 0x1000);
 }
 
 static void rsp_break(unsigned int setbits)
@@ -119,7 +119,7 @@ static void show_cfb(void)
 static int try_fast_audio_dispatching(void)
 {
     /* identify audio ucode by using the content of ucode_data */
-    uint32_t ucode_data = get_task()->ucode_data;
+    uint32_t ucode_data = *dmem_u32(TASK_UCODE_DATA);
 
     if (*dram_u32(ucode_data) == 0x00000001) {
         if (*dram_u32(ucode_data + 0x30) == 0xf0000f00) {
@@ -174,9 +174,7 @@ static int try_fast_audio_dispatching(void)
 static int try_fast_task_dispatching(void)
 {
     /* identify task ucode by its type */
-    const OSTask_t *const task = get_task();
-
-    switch (task->type) {
+    switch (*dmem_u32(TASK_TYPE)) {
     case 1:
         if (FORWARD_GFX) {
             forward_gfx_task();
@@ -202,9 +200,8 @@ static int try_fast_task_dispatching(void)
 
 static void normal_task_dispatching(void)
 {
-    const OSTask_t *const task = get_task();
     const unsigned int sum =
-        sum_bytes(dram_u8(task->ucode), min(task->ucode_size, 0xf80) >> 1);
+        sum_bytes(dram_u8(*dmem_u32(TASK_UCODE)), min(*dmem_u32(TASK_UCODE_SIZE), 0xf80) >> 1);
 
     switch (sum) {
     /* StoreVe12: found in Zelda Ocarina of Time [misleading task->type == 4] */
@@ -258,33 +255,35 @@ static void non_task_dispatching(void)
 static void handle_unknown_task(unsigned int sum)
 {
     char filename[256];
-    const OSTask_t *const task = get_task();
+    uint32_t ucode = *dmem_u32(TASK_UCODE);
+    uint32_t ucode_data = *dmem_u32(TASK_UCODE_DATA);
+    uint32_t data_ptr = *dmem_u32(TASK_DATA_PTR);
 
     DebugMessage(M64MSG_WARNING, "unknown OSTask: sum %x PC:%x", sum, *rsp.SP_PC_REG);
 
     sprintf(&filename[0], "task_%x.log", sum);
-    dump_task(filename, task);
+    dump_task(filename);
 
     /* dump ucode_boot */
     sprintf(&filename[0], "ucode_boot_%x.bin", sum);
-    dump_binary(filename, dram_u8(task->ucode_boot), task->ucode_boot_size);
+    dump_binary(filename, dram_u8(*dmem_u32(TASK_UCODE_BOOT)), *dmem_u32(TASK_UCODE_BOOT_SIZE));
 
     /* dump ucode */
-    if (task->ucode != 0) {
+    if (ucode != 0) {
         sprintf(&filename[0], "ucode_%x.bin", sum);
-        dump_binary(filename, dram_u8(task->ucode), 0xf80);
+        dump_binary(filename, dram_u8(ucode), 0xf80);
     }
 
     /* dump ucode_data */
-    if (task->ucode_data != 0) {
+    if (ucode_data != 0) {
         sprintf(&filename[0], "ucode_data_%x.bin", sum);
-        dump_binary(filename, dram_u8(task->ucode_data), task->ucode_data_size);
+        dump_binary(filename, dram_u8(ucode_data), *dmem_u32(TASK_UCODE_DATA_SIZE));
     }
 
     /* dump data */
-    if (task->data_ptr != 0) {
+    if (data_ptr != 0) {
         sprintf(&filename[0], "data_%x.bin", sum);
-        dump_binary(filename, dram_u8(task->data_ptr), task->data_size);
+        dump_binary(filename, dram_u8(data_ptr), *dmem_u32(TASK_DATA_SIZE));
     }
 }
 
@@ -432,7 +431,7 @@ static void dump_binary(const char *const filename, const unsigned char *const b
         fclose(f);
 }
 
-static void dump_task(const char *const filename, const OSTask_t *const task)
+static void dump_task(const char *const filename)
 {
     FILE *f;
 
@@ -449,14 +448,15 @@ static void dump_task(const char *const filename, const OSTask_t *const task)
                 "output_buff = %#08x *size = %#x\n"
                 "data        = %#08x size  = %#x\n"
                 "yield_data  = %#08x size  = %#x\n",
-                task->type, task->flags,
-                task->ucode_boot, task->ucode_boot_size,
-                task->ucode, task->ucode_size,
-                task->ucode_data, task->ucode_data_size,
-                task->dram_stack, task->dram_stack_size,
-                task->output_buff, task->output_buff_size,
-                task->data_ptr, task->data_size,
-                task->yield_data_ptr, task->yield_data_size);
+                *dmem_u32(TASK_TYPE),
+                *dmem_u32(TASK_FLAGS),
+                *dmem_u32(TASK_UCODE_BOOT),     *dmem_u32(TASK_UCODE_BOOT_SIZE),
+                *dmem_u32(TASK_UCODE),          *dmem_u32(TASK_UCODE_SIZE),
+                *dmem_u32(TASK_UCODE_DATA),     *dmem_u32(TASK_UCODE_DATA_SIZE),
+                *dmem_u32(TASK_DRAM_STACK),     *dmem_u32(TASK_DRAM_STACK_SIZE),
+                *dmem_u32(TASK_OUTPUT_BUFF),    *dmem_u32(TASK_OUTPUT_BUFF_SIZE),
+                *dmem_u32(TASK_DATA_PTR),       *dmem_u32(TASK_DATA_SIZE),
+                *dmem_u32(TASK_YIELD_DATA_PTR), *dmem_u32(TASK_YIELD_DATA_SIZE));
         fclose(f);
     } else
         fclose(f);

--- a/src/musyx.c
+++ b/src/musyx.c
@@ -195,10 +195,8 @@ static int32_t dot4(const int16_t *x, const int16_t *y)
  **************************************************************************/
 void musyx_task(void)
 {
-    const OSTask_t *const task = get_task();
-
-    uint32_t sfd_ptr   = task->data_ptr;
-    uint32_t sfd_count = task->data_size;
+    uint32_t sfd_ptr   = *dmem_u32(TASK_DATA_PTR);
+    uint32_t sfd_count = *dmem_u32(TASK_DATA_SIZE);
     uint32_t state_ptr;
     musyx_t musyx;
 


### PR DESCRIPTION
Accessing RDRAM of DMEM using only pointers provided by RSP_INFO structure can be error prone because of endianness  and address mask issues. These commits provides a uniformized way of accessing RDRAM and DMEM which should be less error-prone.

Furthermore, it replaces the fragile OSTask_t structure by direct dmem primitives, and therefore avoid struct members alignment pitfalls.
