### PR TITLE
Fix ucode CIC x105 detection after reset

### DIFF
--- a/src/hle.c
+++ b/src/hle.c
@@ -326,12 +326,11 @@ static void normal_task_dispatching(struct hle_t* hle)
 
 static void non_task_dispatching(struct hle_t* hle)
 {
-    const unsigned int sum = sum_bytes(hle->imem, 0x1000 >> 1);
+    const unsigned int sum = sum_bytes(hle->imem, 44);
 
-    switch (sum) {
-    /* CIC x105 ucode (used during boot of CIC x105 games) */
-    case 0x9e2: /* CIC 6105 */
-    case 0x9f2: /* CIC 7105 */
+    if (sum == 0x9e2)
+    {
+        /* CIC x105 ucode (used during boot of CIC x105 games) */
         cicx105_ucode(hle);
         return;
     }


### PR DESCRIPTION
After reset, IMEM could contain garbage which could interfere with ucode identification.
To avoid that, we reduce the length used to compute the ucode sum.

Furthermore, after fixing PIFBoot ROM emulation in mupen64plus-core (pull request #41), there is no need
for different values for CIC 6105 and CIC 7105.
