### PR TITLE
Add a MIPS support stanza for the Unix Makefile

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -111,6 +111,12 @@ ifneq ("$(filter arm%,$(HOST_CPU))","")
     $(warning Architecture "$(HOST_CPU)" not officially supported.')
   endif
 endif
+ifneq ("$(filter mips,$(HOST_CPU))","")
+  CPU := MIPS
+  ARCH_DETECTED := 32BITS
+  PIC ?= 1
+  $(warning Architecture "$(HOST_CPU)" not officially supported.')
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'http://code.google.com/p/mupen64plus/issues')
 endif


### PR DESCRIPTION
The Mupen64Plus HLE RSP plugin is sensitive to the architecture it's compiled for, to the extent that it writes interleaved audio in a certain order depending on `BIG_ENDIAN` (`-DM64P_BIG_ENDIAN`).

I attach a commit that adds unofficial support for little-endian MIPS as a build target.

I do not have access to a big-endian MIPS host to check its `uname -m` output. It is possible that my proposed stanza compiles for big-endian MIPS as if it were little-endian, if the output includes `mips` (for example `mipseb`). It seems that the only impact would be reversed stereo, however.