### PR TITLE
Discard highest 2 bits for segment selection

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -119,7 +119,7 @@ void alist_process(struct hle_t* hle, const acmd_callback_t abi[], unsigned int 
 
 uint32_t alist_get_address(struct hle_t* hle, uint32_t so, const uint32_t *segments, size_t n)
 {
-    uint8_t  segment = (so >> 24);
+    uint8_t  segment = (so >> 24) & 0x3f;
     uint32_t offset  = (so & 0xffffff);
 
     if (segment >= n) {
@@ -132,7 +132,7 @@ uint32_t alist_get_address(struct hle_t* hle, uint32_t so, const uint32_t *segme
 
 void alist_set_address(struct hle_t* hle, uint32_t so, uint32_t *segments, size_t n)
 {
-    uint8_t  segment = (so >> 24);
+    uint8_t  segment = (so >> 24) & 0x3f;
     uint32_t offset  = (so & 0xffffff);
 
     if (segment >= n) {


### PR DESCRIPTION
This avoids constant spamming in Aidyn Chronicles.