### PR TITLE
Prevent CLEARBUFF for naudio and nead from deriving a count too big for alist_buffer

### DIFF
--- a/src/alist_naudio.c
+++ b/src/alist_naudio.c
@@ -152,7 +152,7 @@ static void ENVMIXER(struct hle_t* hle, uint32_t w1, uint32_t w2)
 static void CLEARBUFF(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     uint16_t dmem  = w1 + NAUDIO_MAIN;
-    uint16_t count = w2;
+    uint16_t count = w2 & 0xfff;
 
     alist_clear(hle, dmem, count);
 }

--- a/src/alist_nead.c
+++ b/src/alist_nead.c
@@ -92,7 +92,7 @@ static void ADPCM(struct hle_t* hle, uint32_t w1, uint32_t w2)
 static void CLEARBUFF(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     uint16_t dmem  = w1;
-    uint16_t count = w2;
+    uint16_t count = w2 & 0xfff;
 
     if (count == 0)
         return;


### PR DESCRIPTION
alist_buffer max size is 0x1000, so using 0xFFF as mask. This prevents a crash happening due to addressing past the end of alist_buffer. See this issue:

https://github.com/mupen64plus/mupen64plus-core/issues/219#issuecomment-279982285
