### PR TITLE
Prevent more illegal accesses of alist_buffer

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -50,12 +50,12 @@ static void swap(int16_t **a, int16_t **b)
 
 static int16_t* sample(struct hle_t* hle, unsigned pos)
 {
-    return (int16_t*)hle->alist_buffer + (pos ^ S);
+    return (int16_t*)hle->alist_buffer + ((pos ^ S) & 0xfff);
 }
 
 static uint8_t* alist_u8(struct hle_t* hle, uint16_t dmem)
 {
-    return u8(hle->alist_buffer, dmem);
+    return (uint8_t*)(hle->alist_buffer + ((dmem ^ S8) & 0xfff));
 }
 
 static int16_t* alist_s16(struct hle_t* hle, uint16_t dmem)

--- a/src/alist_audio.c
+++ b/src/alist_audio.c
@@ -57,7 +57,7 @@ static void SPNOOP(struct hle_t* UNUSED(hle), uint32_t UNUSED(w1), uint32_t UNUS
 static void CLEARBUFF(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     uint16_t dmem  = w1 + DMEM_BASE;
-    uint16_t count = w2;
+    uint16_t count = w2 & 0xfff;
 
     if (count == 0)
         return;

--- a/src/alist_nead.c
+++ b/src/alist_nead.c
@@ -300,7 +300,7 @@ static void ADDMIXER(struct hle_t* hle, uint32_t w1, uint32_t w2)
 static void HILOGAIN(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     int8_t   gain  = (w1 >> 16); /* Q4.4 signed */
-    uint16_t count = w1;
+    uint16_t count = w1 & 0xfff;
     uint16_t dmem  = (w2 >> 16);
 
     alist_multQ44(hle, dmem, count, gain);


### PR DESCRIPTION
I found a few more places where we are crashing due to accessing past the alist_buffer array.