### PR TITLE
Prevent yet one more illegal access to alist_buffer

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -60,7 +60,7 @@ static uint8_t* alist_u8(struct hle_t* hle, uint16_t dmem)
 
 static int16_t* alist_s16(struct hle_t* hle, uint16_t dmem)
 {
-    return (int16_t*)u16(hle->alist_buffer, dmem);
+    return (int16_t*)(hle->alist_buffer + ((dmem ^ S16) & 0xfff));
 }
 
 


### PR DESCRIPTION
This is yet another illegal access that I saw on a reported crash report for mupen64plus-ae.

After the previous fixes though, I have seen many less reports, just this one is left.