### PR TITLE
Update Copyright

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -1,6 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
  *   Mupen64plus-rsp-hle - alist.c                                         *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2016 Project64. All rights reserved.                    *
  *   Copyright (C) 2014 Bobby Smiles                                       *
  *   Copyright (C) 2009 Richard Goedeken                                   *
  *   Copyright (C) 2002 Hacktarux                                          *


### PR DESCRIPTION
Portions of code in this file were copied verbatim from Project64. I neglected to update the copyright at that time. This was an oversight on my part, I apologize.

https://github.com/mupen64plus/mupen64plus-rsp-hle/pull/40
https://github.com/mupen64plus/mupen64plus-rsp-hle/pull/43