### PR TITLE
Let each ucode specify how sp status should be modified.

### DIFF
--- a/src/alist_audio.c
+++ b/src/alist_audio.c
@@ -278,6 +278,7 @@ void alist_process_audio(struct hle_t* hle)
 
     clear_segments(hle);
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_audio_ge(struct hle_t* hle)
@@ -291,6 +292,7 @@ void alist_process_audio_ge(struct hle_t* hle)
 
     clear_segments(hle);
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_audio_bc(struct hle_t* hle)
@@ -304,4 +306,5 @@ void alist_process_audio_bc(struct hle_t* hle)
 
     clear_segments(hle);
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }

--- a/src/alist_naudio.c
+++ b/src/alist_naudio.c
@@ -274,6 +274,7 @@ void alist_process_naudio(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_naudio_bk(struct hle_t* hle)
@@ -287,6 +288,7 @@ void alist_process_naudio_bk(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_naudio_dk(struct hle_t* hle)
@@ -300,6 +302,7 @@ void alist_process_naudio_dk(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_naudio_mp3(struct hle_t* hle)
@@ -312,6 +315,7 @@ void alist_process_naudio_mp3(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_naudio_cbfd(struct hle_t* hle)
@@ -325,4 +329,5 @@ void alist_process_naudio_cbfd(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x10);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }

--- a/src/alist_nead.c
+++ b/src/alist_nead.c
@@ -372,6 +372,7 @@ void alist_process_nead_mk(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x20);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_sf(struct hle_t* hle)
@@ -388,6 +389,7 @@ void alist_process_nead_sf(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x20);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_sfj(struct hle_t* hle)
@@ -404,6 +406,7 @@ void alist_process_nead_sfj(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x20);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_fz(struct hle_t* hle)
@@ -420,6 +423,7 @@ void alist_process_nead_fz(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x20);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_wrjb(struct hle_t* hle)
@@ -436,6 +440,7 @@ void alist_process_nead_wrjb(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x20);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_ys(struct hle_t* hle)
@@ -450,6 +455,7 @@ void alist_process_nead_ys(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_1080(struct hle_t* hle)
@@ -464,6 +470,7 @@ void alist_process_nead_1080(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_oot(struct hle_t* hle)
@@ -478,6 +485,7 @@ void alist_process_nead_oot(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_mm(struct hle_t* hle)
@@ -492,6 +500,7 @@ void alist_process_nead_mm(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_mmb(struct hle_t* hle)
@@ -506,6 +515,7 @@ void alist_process_nead_mmb(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 void alist_process_nead_ac(struct hle_t* hle)
@@ -520,4 +530,5 @@ void alist_process_nead_ac(struct hle_t* hle)
     };
 
     alist_process(hle, ABI, 0x18);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }

--- a/src/cicx105.c
+++ b/src/cicx105.c
@@ -50,5 +50,7 @@ void cicx105_ucode(struct hle_t* hle)
         src += 0x8;
 
     }
+
+    rsp_break(hle, 0);
 }
 

--- a/src/hle_internal.h
+++ b/src/hle_internal.h
@@ -74,5 +74,16 @@ struct hle_t
     uint8_t  mp3_buffer[0x1000];
 };
 
+/* some mips interface interrupt flags */
+#define MI_INTR_SP                  0x1
+
+/* some rsp status flags */
+#define SP_STATUS_HALT             0x1
+#define SP_STATUS_BROKE            0x2
+#define SP_STATUS_INTR_ON_BREAK    0x40
+#define SP_STATUS_TASKDONE         0x200
+
+void rsp_break(struct hle_t* hle, unsigned int setbits);
+
 #endif
 

--- a/src/jpeg.c
+++ b/src/jpeg.c
@@ -141,6 +141,7 @@ static const float IDCT_K[10] = {
 void jpeg_decode_PS0(struct hle_t* hle)
 {
     jpeg_decode_std(hle, "PS0", RescaleYSubBlock, RescaleUVSubBlock, EmitYUVTileLine);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 /***************************************************************************
@@ -150,6 +151,7 @@ void jpeg_decode_PS0(struct hle_t* hle)
 void jpeg_decode_PS(struct hle_t* hle)
 {
     jpeg_decode_std(hle, "PS", NULL, NULL, EmitRGBATileLine);
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 /***************************************************************************
@@ -190,6 +192,7 @@ void jpeg_decode_OB(struct hle_t* hle)
 
         address += (2 * 6 * SUBBLOCK_SIZE);
     }
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 

--- a/src/musyx.c
+++ b/src/musyx.c
@@ -256,6 +256,8 @@ void musyx_v1_task(struct hle_t* hle)
     dram_store_u16(hle, (uint16_t *)musyx.cc0, state_ptr + STATE_CC0, SUBFRAME_SIZE);
     dram_store_u16(hle, (uint16_t *)musyx.subframe_740_last4, state_ptr + STATE_740_LAST4_V1,
               4);
+
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 /**************************************************************************
@@ -333,6 +335,8 @@ void musyx_v2_task(struct hle_t* hle)
 
         sfd_ptr += SFD2_VOICES + MAX_VOICES * VOICE_SIZE;
     }
+
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }
 
 

--- a/src/re2.c
+++ b/src/re2.c
@@ -94,4 +94,6 @@ void resize_bilinear_task(struct hle_t* hle)
         }
         y += y_ratio;
     }
+
+    rsp_break(hle, SP_STATUS_TASKDONE);
 }


### PR DESCRIPTION
Most ucodes are executed until task is done (in one go).
However, some ucodes (yet to be implemented such as wdc zsort) may need
to yield thus not setting task done flag.