### PR TITLE
Implement RSP fallback.

### DIFF
--- a/projects/VisualStudio2013/mupen64plus-rsp-hle.vcxproj
+++ b/projects/VisualStudio2013/mupen64plus-rsp-hle.vcxproj
@@ -172,6 +172,7 @@
     <ClCompile Include="..\..\src\memory.c" />
     <ClCompile Include="..\..\src\mp3.c" />
     <ClCompile Include="..\..\src\musyx.c" />
+    <ClCompile Include="..\..\src\osal_dynamiclib_win32.c" />
     <ClCompile Include="..\..\src\plugin.c" />
     <ClCompile Include="..\..\src\re2.c" />
   </ItemGroup>
@@ -184,6 +185,7 @@
     <ClInclude Include="..\..\src\hle_external.h" />
     <ClInclude Include="..\..\src\hle_internal.h" />
     <ClInclude Include="..\..\src\memory.h" />
+    <ClInclude Include="..\..\src\osal_dynamiclib.h" />
     <ClInclude Include="..\..\src\ucodes.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -151,6 +151,7 @@ endif
 ifeq ($(OS), LINUX)
   # only export api symbols
   LDFLAGS += -Wl,-version-script,$(SRCDIR)/rsp_api_export.ver
+  LDLIBS += -ldl
 endif
 ifeq ($(OS), OSX)
   #xcode-select has been around since XCode 3.0, i.e. OS X 10.5
@@ -250,6 +251,14 @@ SOURCE = \
 	$(SRCDIR)/musyx.c \
 	$(SRCDIR)/re2.c \
 	$(SRCDIR)/plugin.c
+
+ifeq ($(OS), MINGW)
+SOURCE += \
+	$(SRCDIR)/osal_dynamiclib_win32.c
+else
+SOURCE += \
+	$(SRCDIR)/osal_dynamiclib_unix.c
+endif
 
 # generate a list of object files build, make a temporary directory for them
 OBJECTS := $(patsubst $(SRCDIR)/%.c, $(OBJDIR)/%.o, $(filter %.c, $(SOURCE)))

--- a/src/alist_nead.c
+++ b/src/alist_nead.c
@@ -532,3 +532,25 @@ void alist_process_nead_ac(struct hle_t* hle)
     alist_process(hle, ABI, 0x18);
     rsp_break(hle, SP_STATUS_TASKDONE);
 }
+
+void alist_process_nead_mats(struct hle_t* hle)
+{
+    /* FIXME: implement proper ucode
+     * Forward the task if possible,
+     * otherwise better to have no sound than garbage sound
+     */
+    if (HleForwardTask(hle->user_defined) != 0) {
+        rsp_break(hle, SP_STATUS_TASKDONE);
+    }
+}
+
+void alist_process_nead_efz(struct hle_t* hle)
+{
+    /* FIXME: implement proper ucode
+     * Forward the task if possible,
+     * otherwise use FZero ucode which should be very similar
+     */
+    if (HleForwardTask(hle->user_defined) != 0) {
+        alist_process_nead_fz(hle);
+    }
+}

--- a/src/hle.c
+++ b/src/hle.c
@@ -273,8 +273,7 @@ static bool try_fast_task_dispatching(struct hle_t* hle)
 
     case 7:
         HleShowCFB(hle->user_defined);
-        rsp_break(hle, SP_STATUS_TASKDONE);
-        return true;
+        break;
     }
 
     return false;

--- a/src/hle.c
+++ b/src/hle.c
@@ -43,12 +43,12 @@
 /* helper functions prototypes */
 static unsigned int sum_bytes(const unsigned char *bytes, unsigned int size);
 static bool is_task(struct hle_t* hle);
-static void forward_gfx_task(struct hle_t* hle);
+static void send_dlist_to_gfx_plugin(struct hle_t* hle);
 static bool try_fast_audio_dispatching(struct hle_t* hle);
 static bool try_fast_task_dispatching(struct hle_t* hle);
 static void normal_task_dispatching(struct hle_t* hle);
 static void non_task_dispatching(struct hle_t* hle);
-static void re2_task_dispatching(struct hle_t* hle);
+static bool try_re2_task_dispatching(struct hle_t* hle);
 
 #ifdef ENABLE_TASK_DUMP
 static void dump_binary(struct hle_t* hle, const char *const filename,
@@ -57,9 +57,6 @@ static void dump_task(struct hle_t* hle, const char *const filename);
 static void dump_unknown_task(struct hle_t* hle, unsigned int sum);
 static void dump_unknown_non_task(struct hle_t* hle, unsigned int sum);
 #endif
-
-/* local variables */
-static const bool FORWARD_AUDIO = false, FORWARD_GFX = true;
 
 /* Global functions */
 void hle_init(struct hle_t* hle,
@@ -157,7 +154,13 @@ void rsp_break(struct hle_t* hle, unsigned int setbits)
     }
 }
 
-static void forward_gfx_task(struct hle_t* hle)
+static void send_alist_to_audio_plugin(struct hle_t* hle)
+{
+    HleProcessAlistList(hle->user_defined);
+    rsp_break(hle, SP_STATUS_TASKDONE);
+}
+
+static void send_dlist_to_gfx_plugin(struct hle_t* hle)
 {
     HleProcessDlistList(hle->user_defined);
     rsp_break(hle, SP_STATUS_TASKDONE);
@@ -251,20 +254,18 @@ static bool try_fast_task_dispatching(struct hle_t* hle)
     case 1:
         /* Resident evil 2 */
         if (*dmem_u32(hle, TASK_DATA_PTR) == 0) {
-            re2_task_dispatching(hle);
-            return true;
+            return try_re2_task_dispatching(hle);
         }
 
-        if (FORWARD_GFX) {
-            forward_gfx_task(hle);
+        if (hle->hle_gfx) {
+            send_dlist_to_gfx_plugin(hle);
             return true;
         }
         break;
 
     case 2:
-        if (FORWARD_AUDIO) {
-            HleProcessAlistList(hle->user_defined);
-            rsp_break(hle, SP_STATUS_TASKDONE);
+        if (hle->hle_aud) {
+            send_alist_to_audio_plugin(hle);
             return true;
         } else if (try_fast_audio_dispatching(hle))
             return true;
@@ -293,8 +294,8 @@ static void normal_task_dispatching(struct hle_t* hle)
 
     /* GFX: Twintris [misleading task->type == 0] */
     case 0x212ee:
-        if (FORWARD_GFX) {
-            forward_gfx_task(hle);
+        if (hle->hle_gfx) {
+            send_dlist_to_gfx_plugin(hle);
             return;
         }
         break;
@@ -316,13 +317,18 @@ static void normal_task_dispatching(struct hle_t* hle)
         return;
     }
 
-    /* Send task_done signal for unknown ucodes to allow further processings */
-    rsp_break(hle, SP_STATUS_TASKDONE);
+    /* Forward task to RSP Fallback.
+     * If task is not forwarded, use the regular "unknown task" path */
+    if (HleForwardTask(hle->user_defined) != 0) {
 
-    HleWarnMessage(hle->user_defined, "unknown OSTask: sum: %x PC:%x", sum, *hle->sp_pc);
+        /* Send task_done signal for unknown ucodes to allow further processings */
+        rsp_break(hle, SP_STATUS_TASKDONE);
+
+        HleWarnMessage(hle->user_defined, "unknown OSTask: sum: %x PC:%x", sum, *hle->sp_pc);
 #ifdef ENABLE_TASK_DUMP
-    dump_unknown_task(hle, sum);
+        dump_unknown_task(hle, sum);
 #endif
+    }
 }
 
 static void non_task_dispatching(struct hle_t* hle)
@@ -336,41 +342,45 @@ static void non_task_dispatching(struct hle_t* hle)
         return;
     }
 
-    HleWarnMessage(hle->user_defined, "unknown RSP code: sum: %x PC:%x", sum, *hle->sp_pc);
+    /* Forward task to RSP Fallback.
+     * If task is not forwarded, use the regular "unknown ucode" path */
+    if (HleForwardTask(hle->user_defined) != 0) {
+
+        HleWarnMessage(hle->user_defined, "unknown RSP code: sum: %x PC:%x", sum, *hle->sp_pc);
 #ifdef ENABLE_TASK_DUMP
-    dump_unknown_non_task(hle, sum);
+        dump_unknown_non_task(hle, sum);
 #endif
+    }
 }
 
 /* Resident evil 2 */
-static void re2_task_dispatching(struct hle_t* hle)
+static bool try_re2_task_dispatching(struct hle_t* hle)
 {
     const unsigned int sum =
         sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), 256);
-    
+
     switch (sum) {
-    
+
     case 0x450f:
         resize_bilinear_task(hle);
-        return;
-    
+        return true;
+
     case 0x3b44:
         decode_video_frame_task(hle);
-        return;
+        return true;
 
     case 0x3d84:
-        /* TODO: Nothing to emulate? */
-        rsp_break(hle, SP_STATUS_TASKDONE);
-        return;
+        /* FIXME: implement proper ucode
+         * Forward the task if possible,
+         * otherwise just skip it as it seems to work OK like that
+         */
+        if (HleForwardTask(hle->user_defined) != 0) {
+            rsp_break(hle, SP_STATUS_TASKDONE);
+        }
+        return true;
     }
 
-    /* Send task_done signal for unknown ucodes to allow further processings */
-    rsp_break(hle, SP_STATUS_TASKDONE);
-
-    HleWarnMessage(hle->user_defined, "unknown OSTask: sum: %x PC:%x", sum, *hle->sp_pc);
-#ifdef ENABLE_TASK_DUMP
-    dump_unknown_task(hle, sum);
-#endif
+    return false;
 }
 
 #ifdef ENABLE_TASK_DUMP

--- a/src/hle.c
+++ b/src/hle.c
@@ -214,7 +214,10 @@ static bool try_fast_audio_dispatching(struct hle_t* hle)
                 alist_process_nead_ac(hle); return true;
             case 0x00010010: /* MusyX v2 (IndianaJones, BattleForNaboo) */
                 musyx_v2_task(hle); return true;
-
+            case 0x1f701238: /* Mario Artist Talent Studio */
+                alist_process_nead_mats(hle); return true;
+            case 0x1f4c1230: /* FZeroX Expansion */
+                alist_process_nead_efz(hle); return true;
             default:
                 HleWarnMessage(hle->user_defined, "ABI2 identification regression: v=%08x", v);
             }

--- a/src/hle_internal.h
+++ b/src/hle_internal.h
@@ -57,6 +57,8 @@ struct hle_t
     /* for user convenience, this will be passed to "external" functions */
     void* user_defined;
 
+    int hle_gfx;
+    int hle_aud;
 
     /* alist.c */
     uint8_t alist_buffer[0x1000];

--- a/src/osal_dynamiclib.h
+++ b/src/osal_dynamiclib.h
@@ -1,7 +1,7 @@
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
- *   Mupen64plus-rsp-hle - hle_external.h                                  *
+ *   Mupen64plus-ui-console - osal_dynamiclib.h                            *
  *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
- *   Copyright (C) 2014 Bobby Smiles                                       *
+ *   Copyright (C) 2009 Richard Goedeken                                   *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,22 +19,16 @@
  *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-#ifndef HLE_EXTERNAL_H
-#define HLE_EXTERNAL_H
+#if !defined(OSAL_DYNAMICLIB_H)
+#define OSAL_DYNAMICLIB_H
 
-/* users of the hle core are expected to define these functions */
+#include "m64p_types.h"
 
-void HleVerboseMessage(void* user_defined, const char *message, ...);
-void HleInfoMessage(void* user_defined, const char *message, ...);
-void HleErrorMessage(void* user_defined, const char *message, ...);
-void HleWarnMessage(void* user_defined, const char *message, ...);
+m64p_error osal_dynlib_open(m64p_dynlib_handle *pLibHandle, const char *pccLibraryPath);
 
-void HleCheckInterrupts(void* user_defined);
-void HleProcessDlistList(void* user_defined);
-void HleProcessAlistList(void* user_defined);
-void HleProcessRdpList(void* user_defined);
-void HleShowCFB(void* user_defined);
-int HleForwardTask(void* user_defined);
+void *     osal_dynlib_getproc(m64p_dynlib_handle LibHandle, const char *pccProcedureName);
 
-#endif
+m64p_error osal_dynlib_close(m64p_dynlib_handle LibHandle);
+
+#endif /* #define OSAL_DYNAMICLIB_H */
 

--- a/src/osal_dynamiclib_unix.c
+++ b/src/osal_dynamiclib_unix.c
@@ -1,0 +1,71 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-ui-console - osal_dynamiclib_unix.c                       *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2009 Richard Goedeken                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "m64p_types.h"
+#include "hle_external.h"
+#include "osal_dynamiclib.h"
+
+m64p_error osal_dynlib_open(m64p_dynlib_handle *pLibHandle, const char *pccLibraryPath)
+{
+    if (pLibHandle == NULL || pccLibraryPath == NULL)
+        return M64ERR_INPUT_ASSERT;
+
+    *pLibHandle = dlopen(pccLibraryPath, RTLD_NOW);
+
+    if (*pLibHandle == NULL)
+    {
+        /* only print an error message if there is a directory separator (/) in the pathname */
+        /* this prevents us from throwing an error for the use case where Mupen64Plus is not installed */
+        if (strchr(pccLibraryPath, '/') != NULL)
+            HleErrorMessage(NULL, "dlopen('%s') failed: %s", pccLibraryPath, dlerror());
+        return M64ERR_INPUT_NOT_FOUND;
+    }
+
+    return M64ERR_SUCCESS;
+}
+
+void * osal_dynlib_getproc(m64p_dynlib_handle LibHandle, const char *pccProcedureName)
+{
+    if (pccProcedureName == NULL)
+        return NULL;
+
+    return dlsym(LibHandle, pccProcedureName);
+}
+
+m64p_error osal_dynlib_close(m64p_dynlib_handle LibHandle)
+{
+    int rval = dlclose(LibHandle);
+
+    if (rval != 0)
+    {
+        HleErrorMessage(NULL, "dlclose() failed: %s", dlerror());
+        return M64ERR_INTERNAL;
+    }
+
+    return M64ERR_SUCCESS;
+}
+
+

--- a/src/osal_dynamiclib_win32.c
+++ b/src/osal_dynamiclib_win32.c
@@ -1,0 +1,75 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-ui-console - osal_dynamiclib_win32.c                      *
+ *   Mupen64Plus homepage: http://code.google.com/p/mupen64plus/           *
+ *   Copyright (C) 2009 Richard Goedeken                                   *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+
+#include "m64p_types.h"
+#include "hle_external.h"
+#include "osal_dynamiclib.h"
+
+m64p_error osal_dynlib_open(m64p_dynlib_handle *pLibHandle, const char *pccLibraryPath)
+{
+    if (pLibHandle == NULL || pccLibraryPath == NULL)
+        return M64ERR_INPUT_ASSERT;
+
+    *pLibHandle = LoadLibrary(pccLibraryPath);
+
+    if (*pLibHandle == NULL)
+    {
+        char *pchErrMsg;
+        DWORD dwErr = GetLastError();
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwErr,
+                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &pchErrMsg, 0, NULL);
+        HleErrorMessage(NULL, "LoadLibrary('%s') error: %s", pccLibraryPath, pchErrMsg);
+        LocalFree(pchErrMsg);
+        return M64ERR_INPUT_NOT_FOUND;
+    }
+
+    return M64ERR_SUCCESS;
+}
+
+void * osal_dynlib_getproc(m64p_dynlib_handle LibHandle, const char *pccProcedureName)
+{
+    if (pccProcedureName == NULL)
+        return NULL;
+
+    return GetProcAddress(LibHandle, pccProcedureName);
+}
+
+m64p_error osal_dynlib_close(m64p_dynlib_handle LibHandle)
+{
+    int rval = FreeLibrary(LibHandle);
+
+    if (rval == 0)
+    {
+        char *pchErrMsg;
+        DWORD dwErr = GetLastError();
+        FormatMessage(FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM, NULL, dwErr,
+                      MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPTSTR) &pchErrMsg, 0, NULL);
+        HleErrorMessage(NULL, "FreeLibrary() error: %s", pchErrMsg);
+        LocalFree(pchErrMsg);
+        return M64ERR_INTERNAL;
+    }
+
+    return M64ERR_SUCCESS;
+}

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -23,18 +23,41 @@
 
 #include <stdarg.h>
 #include <stdio.h>
+#include <string.h>
 
 #include "common.h"
 #include "hle.h"
 #include "hle_internal.h"
+#include "hle_external.h"
 
 #define M64P_PLUGIN_PROTOTYPES 1
 #include "m64p_common.h"
+#include "m64p_config.h"
+#include "m64p_frontend.h"
 #include "m64p_plugin.h"
 #include "m64p_types.h"
 
+#include "osal_dynamiclib.h"
+
+#define CONFIG_API_VERSION       0x020100
+#define CONFIG_PARAM_VERSION     1.00
+
+#define RSP_API_VERSION   0x20000
 #define RSP_HLE_VERSION        0x020500
 #define RSP_PLUGIN_API_VERSION 0x020000
+
+#define RSP_HLE_CONFIG_SECTION "Rsp-HLE"
+#define RSP_HLE_CONFIG_VERSION "Version"
+#define RSP_HLE_CONFIG_FALLBACK "RspFallback"
+#define RSP_HLE_CONFIG_HLE_GFX  "DisplayListToGraphicsPlugin"
+#define RSP_HLE_CONFIG_HLE_AUD  "AudioListToAudioPlugin"
+
+
+#define VERSION_PRINTF_SPLIT(x) (((x) >> 16) & 0xffff), (((x) >> 8) & 0xff), ((x) & 0xff)
+
+/* Handy macro to avoid code bloat when loading symbols */
+#define GET_FUNC(type, field, name) \
+    ((field = (type)osal_dynlib_getproc(handle, name)) != NULL)
 
 /* local variables */
 static struct hle_t g_hle;
@@ -45,9 +68,126 @@ static void (*l_ProcessRdpList)(void) = NULL;
 static void (*l_ShowCFB)(void) = NULL;
 static void (*l_DebugCallback)(void *, int, const char *) = NULL;
 static void *l_DebugCallContext = NULL;
+static m64p_dynlib_handle l_CoreHandle = NULL;
 static int l_PluginInit = 0;
 
+static m64p_handle l_ConfigRspHle;
+static m64p_dynlib_handle l_RspFallback;
+static ptr_InitiateRSP l_InitiateRSP = NULL;
+static ptr_DoRspCycles l_DoRspCycles = NULL;
+static ptr_RomClosed l_RomClosed = NULL;
+static ptr_PluginShutdown l_PluginShutdown = NULL;
+
+/* definitions of pointers to Core functions */
+static ptr_ConfigOpenSection      ConfigOpenSection = NULL;
+static ptr_ConfigDeleteSection    ConfigDeleteSection = NULL;
+static ptr_ConfigSaveSection      ConfigSaveSection = NULL;
+static ptr_ConfigSetParameter     ConfigSetParameter = NULL;
+static ptr_ConfigGetParameter     ConfigGetParameter = NULL;
+static ptr_ConfigSetDefaultInt    ConfigSetDefaultInt = NULL;
+static ptr_ConfigSetDefaultFloat  ConfigSetDefaultFloat = NULL;
+static ptr_ConfigSetDefaultBool   ConfigSetDefaultBool = NULL;
+static ptr_ConfigSetDefaultString ConfigSetDefaultString = NULL;
+static ptr_ConfigGetParamInt      ConfigGetParamInt = NULL;
+static ptr_ConfigGetParamFloat    ConfigGetParamFloat = NULL;
+static ptr_ConfigGetParamBool     ConfigGetParamBool = NULL;
+static ptr_ConfigGetParamString   ConfigGetParamString = NULL;
+static ptr_CoreDoCommand          CoreDoCommand = NULL;
+
 /* local function */
+static void teardown_rsp_fallback()
+{
+    if (l_RspFallback != NULL) {
+        (*l_PluginShutdown)();
+        osal_dynlib_close(l_RspFallback);
+    }
+
+    l_RspFallback = NULL;
+    l_DoRspCycles = NULL;
+    l_InitiateRSP = NULL;
+    l_RomClosed = NULL;
+    l_PluginShutdown = NULL;
+}
+
+static void setup_rsp_fallback(const char* rsp_fallback_path)
+{
+    m64p_dynlib_handle handle = NULL;
+
+    /* reset rsp fallback */
+    teardown_rsp_fallback();
+
+    if (rsp_fallback_path == NULL || strlen(rsp_fallback_path) == 0) {
+        HleInfoMessage(NULL, "RSP Fallback disabled !");
+        return;
+    }
+
+    /* load plugin */
+    if (osal_dynlib_open(&handle, rsp_fallback_path) != M64ERR_SUCCESS) {
+        HleErrorMessage(NULL, "Can't load library: %s", rsp_fallback_path);
+        return;
+    }
+
+    /* call the GetVersion function for the plugin and check compatibility */
+    ptr_PluginGetVersion PluginGetVersion = (ptr_PluginGetVersion) osal_dynlib_getproc(handle, "PluginGetVersion");
+    if (PluginGetVersion == NULL)
+    {
+        HleErrorMessage(NULL, "library '%s' is not a Mupen64Plus library.", rsp_fallback_path);
+        goto close_handle;
+    }
+
+    m64p_plugin_type plugin_type = (m64p_plugin_type)0;
+    int plugin_version = 0;
+    const char *plugin_name = NULL;
+    int api_version = 0;
+
+    (*PluginGetVersion)(&plugin_type, &plugin_version, &api_version, &plugin_name, NULL);
+
+    if (plugin_type != M64PLUGIN_RSP) {
+        HleErrorMessage(NULL, "plugin %s is not an RSP plugin (%u)", plugin_name, plugin_type);
+        goto close_handle;
+    }
+
+    if ((api_version & 0xffff0000) != (RSP_API_VERSION & 0xffff0000)) {
+        HleErrorMessage(NULL, "plugin %s. Version mismatch: %u.%u. Expected >= %u.0",
+            plugin_name,
+            (uint16_t)(api_version >> 16),
+            (uint16_t)(api_version),
+            (uint16_t)(RSP_API_VERSION >> 16));
+        goto close_handle;
+    }
+
+    /* load functions */
+    ptr_PluginStartup PluginStartup;
+
+    if (!GET_FUNC(ptr_PluginStartup, PluginStartup, "PluginStartup") ||
+        !GET_FUNC(ptr_PluginShutdown, l_PluginShutdown, "PluginShutdown") ||
+        !GET_FUNC(ptr_DoRspCycles, l_DoRspCycles, "DoRspCycles") ||
+        !GET_FUNC(ptr_InitiateRSP, l_InitiateRSP, "InitiateRSP") ||
+        !GET_FUNC(ptr_RomClosed, l_RomClosed, "RomClosed"))
+    {
+        HleErrorMessage(NULL, "broken RSP plugin; function(s) not found.");
+        l_PluginShutdown = NULL;
+        l_DoRspCycles = NULL;
+        l_InitiateRSP = NULL;
+        l_RomClosed = NULL;
+        goto close_handle;
+    }
+
+    /* call the plugin's initialization function and make sure it starts okay */
+    if ((*PluginStartup)(l_CoreHandle, l_DebugCallContext, l_DebugCallback) != M64ERR_SUCCESS) {
+        HleErrorMessage(NULL, "Error: %s plugin library '%s' failed to start.", plugin_name, rsp_fallback_path);
+        goto close_handle;
+    }
+
+    /* OK we're done ! */
+    l_RspFallback = handle;
+    HleInfoMessage(NULL, "RSP Fallback '%s' loaded successfully !", rsp_fallback_path);
+    return;
+
+close_handle:
+    osal_dynlib_close(handle);
+}
+
 static void DebugMessage(int level, const char *message, va_list args)
 {
     char msgbuf[1024];
@@ -66,6 +206,14 @@ void HleVerboseMessage(void* UNUSED(user_defined), const char *message, ...)
     va_list args;
     va_start(args, message);
     DebugMessage(M64MSG_VERBOSE, message, args);
+    va_end(args);
+}
+
+void HleInfoMessage(void* UNUSED(user_defined), const char *message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    DebugMessage(M64MSG_INFO, message, args);
     va_end(args);
 }
 
@@ -126,10 +274,24 @@ void HleShowCFB(void* UNUSED(user_defined))
 }
 
 
+int HleForwardTask(void* user_defined)
+{
+    if (l_DoRspCycles == NULL)
+        return -1;
+
+    (*l_DoRspCycles)(-1);
+    return 0;
+}
+
+
 /* DLL-exported functions */
-EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle UNUSED(CoreLibHandle), void *Context,
+EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle CoreLibHandle, void *Context,
                                      void (*DebugCallback)(void *, int, const char *))
 {
+    ptr_CoreGetAPIVersions CoreAPIVersionFunc;
+    int ConfigAPIVersion, DebugAPIVersion, VidextAPIVersion, bSaveConfig;
+    float fConfigParamsVersion = 0.0f;
+
     if (l_PluginInit)
         return M64ERR_ALREADY_INIT;
 
@@ -137,7 +299,99 @@ EXPORT m64p_error CALL PluginStartup(m64p_dynlib_handle UNUSED(CoreLibHandle), v
     l_DebugCallback = DebugCallback;
     l_DebugCallContext = Context;
 
-    /* this plugin doesn't use any Core library functions (ex for Configuration), so no need to keep the CoreLibHandle */
+    /* attach and call the CoreGetAPIVersions function, check Config API version for compatibility */
+    CoreAPIVersionFunc = (ptr_CoreGetAPIVersions) osal_dynlib_getproc(CoreLibHandle, "CoreGetAPIVersions");
+    if (CoreAPIVersionFunc == NULL)
+    {
+        HleErrorMessage(NULL, "Core emulator broken; no CoreAPIVersionFunc() function found.");
+        return M64ERR_INCOMPATIBLE;
+    }
+
+    (*CoreAPIVersionFunc)(&ConfigAPIVersion, &DebugAPIVersion, &VidextAPIVersion, NULL);
+    if ((ConfigAPIVersion & 0xffff0000) != (CONFIG_API_VERSION & 0xffff0000))
+    {
+        HleErrorMessage(NULL, "Emulator core Config API (v%i.%i.%i) incompatible with plugin (v%i.%i.%i)",
+                VERSION_PRINTF_SPLIT(ConfigAPIVersion), VERSION_PRINTF_SPLIT(CONFIG_API_VERSION));
+        return M64ERR_INCOMPATIBLE;
+    }
+
+    /* Get the core config function pointers from the library handle */
+    ConfigOpenSection = (ptr_ConfigOpenSection) osal_dynlib_getproc(CoreLibHandle, "ConfigOpenSection");
+    ConfigDeleteSection = (ptr_ConfigDeleteSection) osal_dynlib_getproc(CoreLibHandle, "ConfigDeleteSection");
+    ConfigSaveSection = (ptr_ConfigSaveSection) osal_dynlib_getproc(CoreLibHandle, "ConfigSaveSection");
+    ConfigSetParameter = (ptr_ConfigSetParameter) osal_dynlib_getproc(CoreLibHandle, "ConfigSetParameter");
+    ConfigGetParameter = (ptr_ConfigGetParameter) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParameter");
+    ConfigSetDefaultInt = (ptr_ConfigSetDefaultInt) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultInt");
+    ConfigSetDefaultFloat = (ptr_ConfigSetDefaultFloat) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultFloat");
+    ConfigSetDefaultBool = (ptr_ConfigSetDefaultBool) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultBool");
+    ConfigSetDefaultString = (ptr_ConfigSetDefaultString) osal_dynlib_getproc(CoreLibHandle, "ConfigSetDefaultString");
+    ConfigGetParamInt = (ptr_ConfigGetParamInt) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamInt");
+    ConfigGetParamFloat = (ptr_ConfigGetParamFloat) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamFloat");
+    ConfigGetParamBool = (ptr_ConfigGetParamBool) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamBool");
+    ConfigGetParamString = (ptr_ConfigGetParamString) osal_dynlib_getproc(CoreLibHandle, "ConfigGetParamString");
+
+    if (!ConfigOpenSection || !ConfigDeleteSection || !ConfigSetParameter || !ConfigGetParameter ||
+        !ConfigSetDefaultInt || !ConfigSetDefaultFloat || !ConfigSetDefaultBool || !ConfigSetDefaultString ||
+        !ConfigGetParamInt   || !ConfigGetParamFloat   || !ConfigGetParamBool   || !ConfigGetParamString)
+        return M64ERR_INCOMPATIBLE;
+
+    /* ConfigSaveSection was added in Config API v2.1.0 */
+    if (ConfigAPIVersion >= 0x020100 && !ConfigSaveSection)
+        return M64ERR_INCOMPATIBLE;
+
+    /* Get core DoCommand function */
+    CoreDoCommand = (ptr_CoreDoCommand) osal_dynlib_getproc(CoreLibHandle, "CoreDoCommand");
+    if (!CoreDoCommand) {
+        return M64ERR_INCOMPATIBLE;
+    }
+
+    /* get a configuration section handle */
+    if (ConfigOpenSection(RSP_HLE_CONFIG_SECTION, &l_ConfigRspHle) != M64ERR_SUCCESS)
+    {
+        HleErrorMessage(NULL, "Couldn't open config section '" RSP_HLE_CONFIG_SECTION "'");
+        return M64ERR_INPUT_NOT_FOUND;
+    }
+
+    /* check the section version number */
+    bSaveConfig = 0;
+    if (ConfigGetParameter(l_ConfigRspHle, RSP_HLE_CONFIG_VERSION, M64TYPE_FLOAT, &fConfigParamsVersion, sizeof(float)) != M64ERR_SUCCESS)
+    {
+        HleWarnMessage(NULL, "No version number in '" RSP_HLE_CONFIG_SECTION "' config section. Setting defaults.");
+        ConfigDeleteSection(RSP_HLE_CONFIG_SECTION);
+        ConfigOpenSection(RSP_HLE_CONFIG_SECTION, &l_ConfigRspHle);
+        bSaveConfig = 1;
+    }
+    else if (((int) fConfigParamsVersion) != ((int) CONFIG_PARAM_VERSION))
+    {
+        HleWarnMessage(NULL, "Incompatible version %.2f in '" RSP_HLE_CONFIG_SECTION "' config section: current is %.2f. Setting defaults.", fConfigParamsVersion, (float) CONFIG_PARAM_VERSION);
+        ConfigDeleteSection(RSP_HLE_CONFIG_SECTION);
+        ConfigOpenSection(RSP_HLE_CONFIG_SECTION, &l_ConfigRspHle);
+        bSaveConfig = 1;
+    }
+    else if ((CONFIG_PARAM_VERSION - fConfigParamsVersion) >= 0.0001f)
+    {
+        /* handle upgrades */
+        float fVersion = CONFIG_PARAM_VERSION;
+        ConfigSetParameter(l_ConfigRspHle, "Version", M64TYPE_FLOAT, &fVersion);
+        HleInfoMessage(NULL, "Updating parameter set version in '" RSP_HLE_CONFIG_SECTION "' config section to %.2f", fVersion);
+        bSaveConfig = 1;
+    }
+
+    /* set the default values for this plugin */
+    ConfigSetDefaultFloat(l_ConfigRspHle, RSP_HLE_CONFIG_VERSION, CONFIG_PARAM_VERSION,
+        "Mupen64Plus RSP HLE Plugin config parameter version number");
+    ConfigSetDefaultString(l_ConfigRspHle, RSP_HLE_CONFIG_FALLBACK, "",
+        "Path to a RSP plugin which will be used when encountering an unknown ucode."
+        "You can disable this by letting an empty string.");
+    ConfigSetDefaultBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_GFX, 1,
+        "Send display lists to the graphics plugin");
+    ConfigSetDefaultBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_AUD, 0,
+        "Send audio lists to the audio plugin");
+
+    if (bSaveConfig && ConfigAPIVersion >= 0x020100)
+        ConfigSaveSection(RSP_HLE_CONFIG_SECTION);
+
+    l_CoreHandle = CoreLibHandle;
 
     l_PluginInit = 1;
     return M64ERR_SUCCESS;
@@ -151,6 +405,9 @@ EXPORT m64p_error CALL PluginShutdown(void)
     /* reset some local variable */
     l_DebugCallback = NULL;
     l_DebugCallContext = NULL;
+    l_CoreHandle = NULL;
+
+    teardown_rsp_fallback();
 
     l_PluginInit = 0;
     return M64ERR_SUCCESS;
@@ -183,7 +440,7 @@ EXPORT unsigned int CALL DoRspCycles(unsigned int Cycles)
     return Cycles;
 }
 
-EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* UNUSED(CycleCount))
+EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
 {
     hle_init(&g_hle,
              Rsp_Info.RDRAM,
@@ -214,9 +471,37 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* UNUSED(CycleCount)
     l_ProcessAlistList = Rsp_Info.ProcessAlistList;
     l_ProcessRdpList = Rsp_Info.ProcessRdpList;
     l_ShowCFB = Rsp_Info.ShowCFB;
+
+    setup_rsp_fallback(ConfigGetParamString(l_ConfigRspHle, RSP_HLE_CONFIG_FALLBACK));
+
+    m64p_rom_header rom_header;
+    CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(rom_header), &rom_header);
+
+    /* Init hle_gfx and hle_aud variables - with game-specific tweaks */
+    if ((strstr((char*)rom_header.Name, (const char*)"WORLD DRIVER CHAMP") != NULL)
+     || (strstr((char*)rom_header.Name, (const char*)"Indiana Jones") != NULL)
+     || (strstr((char*)rom_header.Name, (const char*)"Battle for Naboo") != NULL)
+     || (strstr((char*)rom_header.Name, (const char*)"Stunt Racer 64") != NULL)
+     || (strstr((char*)rom_header.Name, (const char*)"GAUNTLET LEGENDS") != NULL)) {
+        g_hle.hle_gfx = 0;
+    }
+    else {
+        g_hle.hle_gfx = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_GFX);
+    }
+
+    g_hle.hle_aud = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_AUD);
+
+
+    /* notify fallback plugin */
+    if (l_InitiateRSP) {
+        l_InitiateRSP(Rsp_Info, CycleCount);
+    }
 }
 
 EXPORT void CALL RomClosed(void)
 {
-    /* do nothing */
+    /* notify fallback plugin */
+    if (l_RomClosed) {
+        l_RomClosed();
+    }
 }

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -481,8 +481,7 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
     if ((strstr((char*)rom_header.Name, (const char*)"WORLD DRIVER CHAMP") != NULL)
      || (strstr((char*)rom_header.Name, (const char*)"Indiana Jones") != NULL)
      || (strstr((char*)rom_header.Name, (const char*)"Battle for Naboo") != NULL)
-     || (strstr((char*)rom_header.Name, (const char*)"Stunt Racer 64") != NULL)
-     || (strstr((char*)rom_header.Name, (const char*)"GAUNTLET LEGENDS") != NULL)) {
+     || (strstr((char*)rom_header.Name, (const char*)"Stunt Racer 64") != NULL)) {
         g_hle.hle_gfx = 0;
     }
     else {

--- a/src/ucodes.h
+++ b/src/ucodes.h
@@ -126,7 +126,8 @@ void alist_process_nead_oot (struct hle_t* hle);
 void alist_process_nead_mm  (struct hle_t* hle);
 void alist_process_nead_mmb (struct hle_t* hle);
 void alist_process_nead_ac  (struct hle_t* hle);
-
+void alist_process_nead_mats(struct hle_t* hle);
+void alist_process_nead_efz (struct hle_t* hle);
 
 /* mp3 ucode */
 void mp3_task(struct hle_t* hle, unsigned int index, uint32_t address);


### PR DESCRIPTION
This allows to specify an arbitrary RSP plugin to use when an unknown
ucode is encountered. It is particularly usefull when combined with an
LLE RSP plugin.

Sending audio lists or display lists to audio (resp. gfx) plugins can
also be specified through config parameters. A blacklist of known
problematic gfx ucodes is integrated (same as rsp-cxd4) to avoid sending
them to the gfx plugin.