### PR TITLE
Integrate Hvqm preliminary work (not fully functional yet)

### DIFF
--- a/projects/VisualStudio2017/mupen64plus-rsp-hle.vcxproj
+++ b/projects/VisualStudio2017/mupen64plus-rsp-hle.vcxproj
@@ -141,6 +141,7 @@
     <ClCompile Include="..\..\src\audio.c" />
     <ClCompile Include="..\..\src\cicx105.c" />
     <ClCompile Include="..\..\src\hle.c" />
+    <ClCompile Include="..\..\src\hvqm.c" />
     <ClCompile Include="..\..\src\jpeg.c" />
     <ClCompile Include="..\..\src\memory.c" />
     <ClCompile Include="..\..\src\mp3.c" />

--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -258,6 +258,7 @@ SOURCE = \
 	$(SRCDIR)/audio.c \
 	$(SRCDIR)/cicx105.c \
 	$(SRCDIR)/hle.c \
+	$(SRCDIR)/hvqm.c \
 	$(SRCDIR)/jpeg.c \
 	$(SRCDIR)/memory.c \
 	$(SRCDIR)/mp3.c \

--- a/src/hle.c
+++ b/src/hle.c
@@ -271,6 +271,12 @@ static bool try_fast_task_dispatching(struct hle_t* hle)
             return try_re2_task_dispatching(hle);
         }
 
+        /* Yakouchuu II - Satsujin Kouro */
+        if ((hle->product_code == 0x4e594b4a) && sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), 1488) == 0x19495) {
+            hvqm2_decode_sp1_task(hle);
+            return true;
+        }
+
         if (hle->hle_gfx) {
             send_dlist_to_gfx_plugin(hle);
             return true;
@@ -286,8 +292,8 @@ static bool try_fast_task_dispatching(struct hle_t* hle)
         break;
 
     case 7:
-        HleShowCFB(hle->user_defined);
-        break;
+        hvqm2_decode_sp1_task(hle);
+        return true;
     }
 
     return false;

--- a/src/hle_internal.h
+++ b/src/hle_internal.h
@@ -57,8 +57,12 @@ struct hle_t
     /* for user convenience, this will be passed to "external" functions */
     void* user_defined;
 
+    int once_per_rom;
+
     int hle_gfx;
     int hle_aud;
+
+    uint32_t product_code;
 
     /* alist.c */
     uint8_t alist_buffer[0x1000];

--- a/src/hvqm.c
+++ b/src/hvqm.c
@@ -1,0 +1,325 @@
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *   Mupen64plus-rsp-hle - hvqm.c                                          *
+ *   Mupen64Plus homepage: https://mupen64plus.org/                        *
+ *   Copyright (C) 2018 Gilles Siberlin                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.          *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "hle_external.h"
+#include "hle_internal.h"
+#include "memory.h"
+
+/* Nest size  */
+#define HVQM2_NESTSIZE_L 70	/* Number of elements on long side */
+#define HVQM2_NESTSIZE_S 38	/* Number of elements on short side */
+#define HVQM2_NESTSIZE (HVQM2_NESTSIZE_L * HVQM2_NESTSIZE_S)
+
+struct HVQM2Block {
+  uint8_t nbase;
+  uint8_t dc;
+  uint8_t dc_l;
+  uint8_t dc_r;
+  uint8_t dc_u;
+  uint8_t dc_d;
+};
+
+struct HVQM2Basis {
+  uint8_t sx;
+  uint8_t sy;
+  int16_t scale;
+  uint16_t offset;
+  uint16_t lineskip;
+};
+
+union HVQM2Info {
+  struct HVQM2Block block;
+  struct HVQM2Basis basis;
+  uint8_t byte[8];
+};
+
+struct HVQM2Arg {
+  uint32_t info;                //0x70
+  uint32_t buf;                 //0x74
+  uint16_t buf_width;           //0x78
+  uint8_t chroma_step_h;        //0x7a
+  uint8_t chroma_step_v;        //0x7b
+  uint16_t hmcus;               //0x7c
+  uint16_t vmcus;               //0x7e
+  uint8_t alpha;                //0x80
+  uint8_t nest[HVQM2_NESTSIZE]; //0x81
+};
+
+union VectorResult {
+  int16_t vec[12][8];
+  int16_t vec_half[24][4];
+};
+
+static struct HVQM2Arg arg;
+
+int16_t constant[10][8] = {
+{0x0100,0x0200,0x1000,0x2000,0x8000,0x0001,0x0002,0x0004}, //v2 -> 0
+{0x0008,0x0020,0x0040,0x0080,0x0000,0x0000,0x0000,0x0000}, //v3 -> 1
+{0x0071,0xFFEA,0xFFD2,0x005A,0x3FC0,0x3E00,0x0000,0x0000}, //v4 -> 2
+{0x0002,0x0000,0xFFFF,0xFFFF,0x0002,0x0000,0xFFFF,0xFFFF}, //v5 -> 3
+{0xFFFF,0xFFFF,0x0000,0x0002,0xFFFF,0xFFFF,0x0000,0x0002}, //v6 -> 4
+{0x0002,0x0002,0x0002,0x0002,0x0000,0x0000,0x0000,0x0000}, //v7 -> 5
+{0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF,0xFFFF}, //v8 -> 6
+{0x0000,0x0000,0x0000,0x0000,0x0002,0x0002,0x0002,0x0002}, //v9 -> 7
+{0x0006,0x0008,0x0008,0x0006,0x0008,0x000A,0x000A,0x0008}, //v10 -> 8
+{0x0008,0x000A,0x000A,0x0008,0x0006,0x0008,0x0008,0x0006}  //v11 -> 9
+};
+
+//TOREMOVE
+uint8_t data[] = {
+0x00,0x02,0x00,0x01,0x00,0x20,0x00,0x10,0x01,0x00,0x00,0x80,0x04,0x00,0x02,0x00,
+0x20,0x00,0x08,0x00,0x80,0x00,0x40,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
+0xea,0xff,0x71,0x00,0x5a,0x00,0xd2,0xff,0x00,0x3e,0xc0,0x3f,0x00,0x00,0x00,0x00,
+0xff,0xff,0x00,0x02,0xff,0xff,0x00,0x02,0x02,0x00,0xff,0xff,0x02,0x00,0xff,0xff,
+0x02,0x02,0x02,0x02,0x00,0x00,0x00,0x00,0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
+0x00,0x00,0x00,0x00,0x02,0x02,0x02,0x02,0x06,0x08,0x08,0x06,0x08,0x0a,0x0a,0x08,
+0x08,0x0a,0x0a,0x08,0x06,0x08,0x08,0x06,0x00,0x00,0x00,0x00,0x00,0x00,0x00,0x00
+};
+
+static int process_info(struct hle_t* hle, uint8_t * base, int16_t * out)
+{
+  union HVQM2Info info;
+  int16_t * v1 = out; //v12
+  int16_t * v2 = out + 8; //v13
+  uint8_t nbase = *base;
+
+  dram_load_u8(hle, info.byte, arg.info, 8);
+  arg.info += 8;
+
+  *base = info.block.nbase & 0x7;
+
+  if((info.block.nbase & nbase) != 0)
+    return 0;
+
+  if(info.block.nbase == 0)
+  {
+    //LABEL8
+    for(int i = 0; i < 8; i++)
+    {
+      v1[i] =  constant[8][i] * info.block.dc;
+      v1[i] += constant[3][i] * info.block.dc_l;
+      v1[i] += constant[4][i] * info.block.dc_r;
+      v1[i] += constant[5][i] * info.block.dc_u;
+      v1[i] += constant[6][i] * info.block.dc_d;
+
+      v2[i] =  constant[9][i] * info.block.dc;
+      v2[i] += constant[3][i] * info.block.dc_l;
+      v2[i] += constant[4][i] * info.block.dc_r;
+      v2[i] += constant[6][i] * info.block.dc_u;
+      v2[i] += constant[7][i] * info.block.dc_d;
+
+      v1[i] += constant[0][7];
+      v2[i] += constant[0][7];
+
+      v1[i] = (v1[i] * (uint16_t)constant[0][3]) >> 16;
+      v2[i] = (v2[i] * (uint16_t)constant[0][3]) >> 16;
+    }
+  }
+  else if((info.block.nbase & 0xf) == 0)
+  {
+    //LABEL7
+    union HVQM2Info info1;
+    union HVQM2Info info2;
+
+    dram_load_u8(hle, info1.byte, arg.info, 8);
+    arg.info += 8;
+
+    dram_load_u8(hle, info2.byte, arg.info, 8);
+    arg.info += 8;
+
+    for(int i = 0; i < 8; i++)
+    {
+      v1[i] = info1.byte[i] << 7;
+      v2[i] = info2.byte[i] << 7;
+      v1[i] = (v1[i] * (uint16_t)constant[0][1]) >> 16;
+      v2[i] = (v2[i] * (uint16_t)constant[0][1]) >> 16;
+    }
+  }
+  else if(*base == 0)
+  {
+    //LABEL6
+
+    //TODO
+    //uint8_t dc = info.block.dc; //v16[1]
+    //dram_load_u8(hle, info.byte, arg.info, 8);
+    //arg.info += 8;
+    assert(0);
+  }
+  else
+  {
+    //LABEL5
+    union HVQM2Info info1;
+
+    for(; *base != 0; (*base)--)
+    {
+      dram_load_u8(hle, info1.byte, arg.info, 8);
+      arg.info += 8;
+
+      //TODO
+      //SUBROUTINE3 (HVQM2Basis)
+
+      info.block.nbase &= 8;
+    }
+
+    assert(info.block.nbase == 0);
+
+    //if(info.block.nbase != 0)
+    //  LABEL6
+  }
+
+  return 1;
+}
+
+void hvqm2_decode_sp1_task(struct hle_t* hle)
+{
+  uint32_t uc_data_ptr = *dmem_u32(hle, TASK_UCODE_DATA);
+  uint32_t data_ptr = *dmem_u32(hle, TASK_DATA_PTR);
+
+  (void)uc_data_ptr;
+  assert(memcmp(data, dram_u32(hle, uc_data_ptr), sizeof(data)) == 0);
+  assert((*dmem_u32(hle, TASK_FLAGS) & 0x1) == 0);
+
+  /* Fill HVQM2Arg struct */
+  dram_load_u32(hle, &arg.info, data_ptr, 1); //r13
+  data_ptr += 4;
+  dram_load_u32(hle, &arg.buf, data_ptr, 1);  //r14
+  data_ptr += 4;
+  dram_load_u16(hle, &arg.buf_width, data_ptr, 1);  //r18
+  data_ptr += 2;
+  dram_load_u8(hle, &arg.chroma_step_h, data_ptr, 1);
+  data_ptr += 1;
+  dram_load_u8(hle, &arg.chroma_step_v, data_ptr, 1); //r24 & r23
+  data_ptr += 1;
+  dram_load_u16(hle, &arg.hmcus, data_ptr, 1);  //r16
+  data_ptr += 2;
+  dram_load_u16(hle, &arg.vmcus, data_ptr, 1);  //r17
+  data_ptr += 2;
+  dram_load_u8(hle, &arg.alpha, data_ptr, 1);
+  data_ptr += 1;
+  dram_load_u8(hle, arg.nest, data_ptr, HVQM2_NESTSIZE);
+
+  int16_t alpha = ((int16_t)arg.alpha * (uint16_t)constant[0][1]) >> 16;  //v20
+
+  //int length = 0x10;
+  //int count = arg.chroma_step_v << 2;
+  int skip = arg.buf_width << 1;
+
+  if((arg.chroma_step_v-1) != 0)
+  {
+    assert(arg.chroma_step_v == 2);
+    arg.buf_width <<= 3;
+    arg.buf_width += arg.buf_width;
+  }
+
+  assert((*hle->sp_status & 0x80) == 0);  //SP_STATUS_YIELD
+
+  for(int i = arg.vmcus; i != 0; i--)
+  {
+    int j;
+    uint32_t out;
+
+    for(j = arg.hmcus, out = arg.buf; j != 0; j--, out += 0x10)
+    {
+      union VectorResult result;
+      uint8_t base = 0x80;  //r9
+      uint32_t index = 12; //r20
+
+      if((arg.chroma_step_v - 1) != 0)
+      {
+        index = 8;
+        if(process_info(hle, &base, result.vec[4]) == 0)
+          continue;
+        if(process_info(hle, &base, result.vec[8]) == 0)
+          continue;
+      }
+
+      if(process_info(hle, &base, result.vec[6]) == 0)
+        continue;
+      if(process_info(hle, &base, result.vec[10]) == 0)
+        continue;
+      if(process_info(hle, &base, result.vec[2]) == 0)
+        continue;
+      if(process_info(hle, &base, result.vec[0]) == 0)
+        continue;
+
+      uint32_t out_buf = out;
+      for(int k = 0; k < 4; k++)
+      {
+        int l;
+        int16_t v26[8], v27[8], v28[8];
+
+        for(l = 0; l < 8; l++)
+        {
+          int16_t v24 = result.vec_half[k+4][l >> 1] - constant[1][3];
+          int16_t v25 = result.vec_half[k][l >> 1] - constant[1][3];
+          v28[l] = v24 * constant[2][0];
+          v27[l] = v24 * constant[2][1];
+          v27[l] += v25 * constant[2][2];
+          v26[l] = v25 * constant[2][3];
+        }
+
+        for(l = arg.chroma_step_v; l != 0; l--)
+        {
+          int16_t v23[8], v29[8], v30[8], v31[8];
+
+          memcpy(&v23[0], result.vec_half[index], 4 * sizeof(int16_t));
+          memcpy(&v23[4], result.vec_half[index+8], 4 * sizeof(int16_t));
+          index++;
+
+          for(int m = 0; m < 8; m++)
+          {
+            v23[m] *= constant[1][2];
+            v23[m] += constant[1][1];
+            v29[m] = v23[m] + v26[m];
+            v30[m] = v23[m] + v27[m];
+            v31[m] = v23[m] + v28[m];
+            v29[m] = (v29[m] > 0) ? v29[m] : 0;
+            v30[m] = (v30[m] > 0) ? v30[m] : 0;
+            v31[m] = (v31[m] > 0) ? v31[m] : 0;
+            v29[m] = (v29[m] < constant[2][4]) ? v29[m] : constant[2][4];
+            v30[m] = (v30[m] < constant[2][4]) ? v30[m] : constant[2][4];
+            v31[m] = (v31[m] < constant[2][4]) ? v31[m] : constant[2][4];
+            v29[m] &= constant[2][5];
+            v30[m] &= constant[2][5];
+            v31[m] &= constant[2][5];
+            v29[m] = (uint16_t)v29[m] * constant[0][7];
+            v30[m] = ((uint16_t)v30[m] * (uint16_t)constant[0][3]) >> 16;
+            v31[m] = ((uint16_t)v31[m] * (uint16_t)constant[0][0]) >> 16;
+            v29[m] |= alpha;
+            v29[m] |= v30[m];
+            v29[m] |= v31[m];
+          }
+
+          dram_store_u16(hle, (uint16_t*)v29, out_buf, 8);
+          out_buf += skip;
+        }
+      }
+    }
+    arg.buf += arg.buf_width;
+  }
+
+  rsp_break(hle, SP_STATUS_TASKDONE);
+}

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -423,6 +423,28 @@ EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *Plugi
 
 EXPORT unsigned int CALL DoRspCycles(unsigned int Cycles)
 {
+    /* Since RSP plugin API doesn't provide a "RomOpen" function
+     * we implement one with a flag inside DoRspCycle.
+     * once_per_rom is reset in RomClose. */
+    if (!g_hle.once_per_rom) {
+
+        /* Extract ROM product code so we can roughly identify ROM */
+        m64p_rom_header rom_header;
+        CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(rom_header), &rom_header);
+
+        /* XXX: rom_header structure is WRONG,
+         * so we recompose proper product code from exposed m64p_rom_header */
+        g_hle.product_code
+            = ((uint32_t)rom_header.Manufacturer_ID & UINT32_C(0xff000000))
+            | ((uint32_t)rom_header.Cartridge_ID & UINT32_C(0x00ff)) << 16
+            | ((uint32_t)rom_header.Cartridge_ID & UINT32_C(0xff00))
+            | ((uint32_t)rom_header.Country_code & UINT32_C(0x00ff));
+
+        HleWarnMessage(g_hle.user_defined, "Product Code = %08x", g_hle.product_code);
+
+        g_hle.once_per_rom = 1;
+    }
+
     hle_execute(&g_hle);
     return Cycles;
 }
@@ -461,9 +483,7 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
 
     setup_rsp_fallback(ConfigGetParamString(l_ConfigRspHle, RSP_HLE_CONFIG_FALLBACK));
 
-    m64p_rom_header rom_header;
-    CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(rom_header), &rom_header);
-
+    g_hle.once_per_rom = 0;
     g_hle.hle_gfx = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_GFX);
     g_hle.hle_aud = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_AUD);
 
@@ -475,6 +495,8 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
 
 EXPORT void CALL RomClosed(void)
 {
+    g_hle.once_per_rom = 0;
+
     /* notify fallback plugin */
     if (l_RomClosed) {
         l_RomClosed();

--- a/src/ucodes.h
+++ b/src/ucodes.h
@@ -148,5 +148,8 @@ void resize_bilinear_task(struct hle_t* hle);
 void decode_video_frame_task(struct hle_t* hle);
 void fill_video_double_buffer_task(struct hle_t* hle);
 
+/* hvqm2 ucode */
+void hvqm2_decode_sp1_task(struct hle_t* hle);
+
 #endif
 


### PR DESCRIPTION
Based on work by @Gillou68310. I just "fixed" the task dispatching logic, so that both Pokemon Puzzle league and Sakouchuu II ucodes are properly processed by the RSP.
The ucode is not fully implemented, so we get a corrupted image, but the game keeps playing.

@Gillou68310 or @olivieryuyu If you have time to finish ucode implementation be my guest :)


Partial fix for:
* https://github.com/mupen64plus/mupen64plus-core/issues/546
* https://github.com/gonetz/GLideN64/issues/2167
* https://github.com/gonetz/GLideN64/issues/663