### PR TITLE
Rework detection of GFX tasks which shouldn't be processed by video p…

### DIFF
--- a/src/hle_internal.h
+++ b/src/hle_internal.h
@@ -62,7 +62,7 @@ struct hle_t
     int hle_gfx;
     int hle_aud;
 
-    uint32_t product_code;
+    int try_gfx_task_dispatching;
 
     /* alist.c */
     uint8_t alist_buffer[0x1000];


### PR DESCRIPTION
…lugin (HVQM, RE2)

Partially fixes https://github.com/gonetz/GLideN64/issues/2167.
Video plays, but some "inactive tiles" stays black. Don't know if it's a ucode implementation bug or memory change not detected by the video plugin (didn't tweaked GLideN64 settings).