### PR TITLE
Rework task dispatching implementation

### DIFF
--- a/src/hle.c
+++ b/src/hle.c
@@ -44,18 +44,17 @@
 static unsigned int sum_bytes(const unsigned char *bytes, unsigned int size);
 static bool is_task(struct hle_t* hle);
 static void send_dlist_to_gfx_plugin(struct hle_t* hle);
-static bool try_fast_audio_dispatching(struct hle_t* hle);
-static bool try_fast_task_dispatching(struct hle_t* hle);
-static void normal_task_dispatching(struct hle_t* hle);
-static void non_task_dispatching(struct hle_t* hle);
-static bool try_re2_task_dispatching(struct hle_t* hle);
+static ucode_func_t try_audio_task_detection(struct hle_t* hle);
+static ucode_func_t try_normal_task_detection(struct hle_t* hle);
+static ucode_func_t non_task_detection(struct hle_t* hle);
+static ucode_func_t task_detection(struct hle_t* hle);
 
 #ifdef ENABLE_TASK_DUMP
 static void dump_binary(struct hle_t* hle, const char *const filename,
                         const unsigned char *const bytes, unsigned int size);
 static void dump_task(struct hle_t* hle, const char *const filename);
-static void dump_unknown_task(struct hle_t* hle, unsigned int sum);
-static void dump_unknown_non_task(struct hle_t* hle, unsigned int sum);
+static void dump_unknown_task(struct hle_t* hle, unsigned int uc_start);
+static void dump_unknown_non_task(struct hle_t* hle, unsigned int uc_start);
 #endif
 
 /* Global functions */
@@ -109,12 +108,36 @@ void hle_init(struct hle_t* hle,
 
 void hle_execute(struct hle_t* hle)
 {
-    if (is_task(hle)) {
-        if (!try_fast_task_dispatching(hle))
-            normal_task_dispatching(hle);
-    } else {
-        non_task_dispatching(hle);
+    uint32_t uc_start = *dmem_u32(hle, TASK_UCODE);
+    uint32_t uc_dstart = *dmem_u32(hle, TASK_UCODE_DATA);
+    uint32_t uc_dsize = *dmem_u32(hle, TASK_UCODE_DATA_SIZE);
+
+    bool match = false;
+    struct cached_ucodes_t * cached_ucodes = &hle->cached_ucodes;
+    struct ucode_info_t *info = &cached_ucodes->infos[cached_ucodes->count-1];
+    for (int i = 0; i < cached_ucodes->count; i++)
+    {
+        if (info->uc_start == uc_start && info->uc_dstart == uc_dstart && info->uc_dsize == uc_dsize)
+        {
+            match = true;
+            break;
+        }
+        info--;
     }
+
+    if (!match)
+    {
+        info = &cached_ucodes->infos[cached_ucodes->count];
+        info->uc_start = uc_start;
+        info->uc_dstart = uc_dstart;
+        info->uc_dsize = uc_dsize;
+        info->uc_pfunc = task_detection(hle);
+        cached_ucodes->count++;
+        assert(cached_ucodes->count <= CACHED_UCODES_MAX_SIZE);
+        assert(info->uc_pfunc != NULL);
+    }
+
+    info->uc_pfunc(hle);
 }
 
 /* local functions */
@@ -177,7 +200,43 @@ static void send_dlist_to_gfx_plugin(struct hle_t* hle)
     }
 }
 
-static bool try_fast_audio_dispatching(struct hle_t* hle)
+static void task_done(struct hle_t* hle)
+{
+    rsp_break(hle, SP_STATUS_TASKDONE);
+}
+
+static void unknown_ucode(struct hle_t* hle)
+{
+    /* Forward task to RSP Fallback.
+     * If task is not forwarded, use the regular "unknown ucode" path */
+    if (HleForwardTask(hle->user_defined) != 0) {
+
+        uint32_t uc_start = *dmem_u32(hle, TASK_UCODE);
+        HleWarnMessage(hle->user_defined, "unknown RSP code: uc_start: %x PC:%x", uc_start, *hle->sp_pc);
+#ifdef ENABLE_TASK_DUMP
+        dump_unknown_non_task(hle, uc_start);
+#endif
+    }
+}
+
+static void unknown_task(struct hle_t* hle)
+{
+    /* Forward task to RSP Fallback.
+     * If task is not forwarded, use the regular "unknown task" path */
+    if (HleForwardTask(hle->user_defined) != 0) {
+
+        /* Send task_done signal for unknown ucodes to allow further processings */
+        rsp_break(hle, SP_STATUS_TASKDONE);
+
+        uint32_t uc_start = *dmem_u32(hle, TASK_UCODE);
+        HleWarnMessage(hle->user_defined, "unknown OSTask: uc_start: %x PC:%x", uc_start, *hle->sp_pc);
+#ifdef ENABLE_TASK_DUMP
+        dump_unknown_task(hle, uc_start);
+#endif
+    }
+}
+
+static ucode_func_t try_audio_task_detection(struct hle_t* hle)
 {
     /* identify audio ucode by using the content of ucode_data */
     uint32_t ucode_data = *dmem_u32(hle, TASK_UCODE_DATA);
@@ -189,11 +248,11 @@ static bool try_fast_audio_dispatching(struct hle_t* hle)
             switch(v)
             {
             case 0x1e24138c: /* audio ABI (most common) */
-                alist_process_audio(hle); return true;
+                return &alist_process_audio;
             case 0x1dc8138c: /* GoldenEye */
-                alist_process_audio_ge(hle); return true;
+                return &alist_process_audio_ge;
             case 0x1e3c1390: /* BlastCorp, DiddyKongRacing */
-                alist_process_audio_bc(hle); return true;
+                return &alist_process_audio_bc;
             default:
                 HleWarnMessage(hle->user_defined, "ABI1 identification regression: v=%08x", v);
             }
@@ -202,33 +261,33 @@ static bool try_fast_audio_dispatching(struct hle_t* hle)
             switch(v)
             {
             case 0x11181350: /* MarioKart, WaveRace (E) */
-                alist_process_nead_mk(hle); return true;
+                return &alist_process_nead_mk;
             case 0x111812e0: /* StarFox (J) */
-                alist_process_nead_sfj(hle); return true;
+                return &alist_process_nead_sfj;
             case 0x110412ac: /* WaveRace (J RevB) */
-                alist_process_nead_wrjb(hle); return true;
+                return &alist_process_nead_wrjb;
             case 0x110412cc: /* StarFox/LylatWars (except J) */
-                alist_process_nead_sf(hle); return true;
+                return &alist_process_nead_sf;
             case 0x1cd01250: /* FZeroX */
-                alist_process_nead_fz(hle); return true;
+                return &alist_process_nead_fz;
             case 0x1f08122c: /* YoshisStory */
-                alist_process_nead_ys(hle); return true;
+                return &alist_process_nead_ys;
             case 0x1f38122c: /* 1080° Snowboarding */
-                alist_process_nead_1080(hle); return true;
+                return &alist_process_nead_1080;
             case 0x1f681230: /* Zelda OoT / Zelda MM (J, J RevA) */
-                alist_process_nead_oot(hle); return true;
+                return &alist_process_nead_oot;
             case 0x1f801250: /* Zelda MM (except J, J RevA, E Beta), PokemonStadium 2 */
-                alist_process_nead_mm(hle); return true;
+                return &alist_process_nead_mm;
             case 0x109411f8: /* Zelda MM (E Beta) */
-                alist_process_nead_mmb(hle); return true;
+                return &alist_process_nead_mmb;
             case 0x1eac11b8: /* AnimalCrossing */
-                alist_process_nead_ac(hle); return true;
+                return &alist_process_nead_ac;
             case 0x00010010: /* MusyX v2 (IndianaJones, BattleForNaboo) */
-                musyx_v2_task(hle); return true;
+                return &musyx_v2_task;
             case 0x1f701238: /* Mario Artist Talent Studio */
-                alist_process_nead_mats(hle); return true;
+                return &alist_process_nead_mats;
             case 0x1f4c1230: /* FZeroX Expansion */
-                alist_process_nead_efz(hle); return true;
+                return &alist_process_nead_efz;
             default:
                 HleWarnMessage(hle->user_defined, "ABI2 identification regression: v=%08x", v);
             }
@@ -241,204 +300,164 @@ static bool try_fast_audio_dispatching(struct hle_t* hle)
             RogueSquadron, ResidentEvil2, PolarisSnoCross,
             TheWorldIsNotEnough, RugratsInParis, NBAShowTime,
             HydroThunder, Tarzan, GauntletLegend, Rush2049 */
-            musyx_v1_task(hle); return true;
+            return &musyx_v1_task;
         case 0x0000127c: /* naudio (many games) */
-            alist_process_naudio(hle); return true;
+            return &alist_process_naudio;
         case 0x00001280: /* BanjoKazooie */
-            alist_process_naudio_bk(hle); return true;
+            return &alist_process_naudio_bk;
         case 0x1c58126c: /* DonkeyKong */
-            alist_process_naudio_dk(hle); return true;
+            return &alist_process_naudio_dk;
         case 0x1ae8143c: /* BanjoTooie, JetForceGemini, MickeySpeedWayUSA, PerfectDark */
-            alist_process_naudio_mp3(hle); return true;
+            return &alist_process_naudio_mp3;
         case 0x1ab0140c: /* ConkerBadFurDay */
-            alist_process_naudio_cbfd(hle); return true;
+            return &alist_process_naudio_cbfd;
 
         default:
             HleWarnMessage(hle->user_defined, "ABI3 identification regression: v=%08x", v);
         }
     }
 
-    return false;
+    return NULL;
 }
 
-static bool try_fast_task_dispatching(struct hle_t* hle)
+static ucode_func_t try_normal_task_detection(struct hle_t* hle)
 {
-    /* identify task ucode by its type */
-    switch (*dmem_u32(hle, TASK_TYPE)) {
-    case 1:
-        /* Resident evil 2 */
-        if (*dmem_u32(hle, TASK_DATA_PTR) == 0) {
-            return try_re2_task_dispatching(hle);
-        }
-
-        /* Yakouchuu II - Satsujin Kouro */
-        if ((hle->product_code == 0x4e594b4a) && sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), 1488) == 0x19495) {
-            hvqm2_decode_sp1_task(hle);
-            return true;
-        }
-
-        if (hle->hle_gfx) {
-            send_dlist_to_gfx_plugin(hle);
-            return true;
-        }
-        break;
-
-    case 2:
-        if (hle->hle_aud) {
-            send_alist_to_audio_plugin(hle);
-            return true;
-        } else if (try_fast_audio_dispatching(hle))
-            return true;
-        break;
-
-    case 7:
-        hvqm2_decode_sp1_task(hle);
-        return true;
-    }
-
-    return false;
-}
-
-static void normal_task_dispatching(struct hle_t* hle)
-{
-    const unsigned int sum =
+    unsigned int sum =
         sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), min(*dmem_u32(hle, TASK_UCODE_SIZE), 0xf80) >> 1);
 
     switch (sum) {
     /* StoreVe12: found in Zelda Ocarina of Time [misleading task->type == 4] */
     case 0x278:
         /* Nothing to emulate */
-        rsp_break(hle, SP_STATUS_TASKDONE);
-        return;
+        return &task_done;
 
     /* GFX: Twintris [misleading task->type == 0] */
     case 0x212ee:
         if (hle->hle_gfx) {
-            send_dlist_to_gfx_plugin(hle);
-            return;
+            return &send_dlist_to_gfx_plugin;
         }
-        break;
+        return NULL;
 
     /* JPEG: found in Pokemon Stadium J */
     case 0x2c85a:
-        jpeg_decode_PS0(hle);
-        return;
+        return &jpeg_decode_PS0;
 
     /* JPEG: found in Zelda Ocarina of Time, Pokemon Stadium 1, Pokemon Stadium 2 */
     case 0x2caa6:
-        jpeg_decode_PS(hle);
-        return;
+        return &jpeg_decode_PS;
 
     /* JPEG: found in Ogre Battle, Bottom of the 9th */
     case 0x130de:
     case 0x278b0:
-        jpeg_decode_OB(hle);
-        return;
+        return &jpeg_decode_OB;
     }
 
-    /* Forward task to RSP Fallback.
-     * If task is not forwarded, use the regular "unknown task" path */
-    if (HleForwardTask(hle->user_defined) != 0) {
+    sum = sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), 256);
+    switch (sum) {
 
-        /* Send task_done signal for unknown ucodes to allow further processings */
-        rsp_break(hle, SP_STATUS_TASKDONE);
+    case 0x450f:
+        return &resize_bilinear_task;
 
-        HleWarnMessage(hle->user_defined, "unknown OSTask: sum: %x PC:%x", sum, *hle->sp_pc);
-#ifdef ENABLE_TASK_DUMP
-        dump_unknown_task(hle, sum);
-#endif
+    case 0x3b44:
+        return &decode_video_frame_task;
+
+    case 0x3d84:
+        return &fill_video_double_buffer_task;
+
+    case 0x3bde:
+        return &hvqm2_decode_sp1_task;
     }
+
+    return NULL;
 }
 
-static void non_task_dispatching(struct hle_t* hle)
+static ucode_func_t non_task_detection(struct hle_t* hle)
 {
     const unsigned int sum = sum_bytes(hle->imem, 44);
 
     if (sum == 0x9e2)
     {
         /* CIC x105 ucode (used during boot of CIC x105 games) */
-        cicx105_ucode(hle);
-        return;
+        return &cicx105_ucode;
     }
-
-    /* Forward task to RSP Fallback.
-     * If task is not forwarded, use the regular "unknown ucode" path */
-    if (HleForwardTask(hle->user_defined) != 0) {
-
-        HleWarnMessage(hle->user_defined, "unknown RSP code: sum: %x PC:%x", sum, *hle->sp_pc);
-#ifdef ENABLE_TASK_DUMP
-        dump_unknown_non_task(hle, sum);
-#endif
-    }
+    return &unknown_ucode;
 }
 
-/* Resident evil 2 */
-static bool try_re2_task_dispatching(struct hle_t* hle)
+static ucode_func_t task_detection(struct hle_t* hle)
 {
-    const unsigned int sum =
-        sum_bytes((void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE)), 256);
+    if (is_task(hle)) {
+        ucode_func_t uc_pfunc;
+        uint32_t type = *dmem_u32(hle, TASK_TYPE);
 
-    switch (sum) {
+        if (type == 2) {
+            if (hle->hle_aud) {
+                return &send_alist_to_audio_plugin;
+            }
+            uc_pfunc = try_audio_task_detection(hle);
+            if (uc_pfunc)
+                return uc_pfunc;
+        }
 
-    case 0x450f:
-        resize_bilinear_task(hle);
-        return true;
+        uc_pfunc = try_normal_task_detection(hle);
+        if (uc_pfunc)
+            return uc_pfunc;
+        
+        if (type == 1) {
+            if (hle->hle_gfx) {
+                return &send_dlist_to_gfx_plugin;
+            }
+        }
 
-    case 0x3b44:
-        decode_video_frame_task(hle);
-        return true;
-
-    case 0x3d84:
-        fill_video_double_buffer_task(hle);
-        return true;
+        return &unknown_task;
     }
-
-    return false;
+    else {
+        return non_task_detection(hle);
+    }
 }
 
 #ifdef ENABLE_TASK_DUMP
-static void dump_unknown_task(struct hle_t* hle, unsigned int sum)
+static void dump_unknown_task(struct hle_t* hle, unsigned int uc_start)
 {
     char filename[256];
     uint32_t ucode = *dmem_u32(hle, TASK_UCODE);
     uint32_t ucode_data = *dmem_u32(hle, TASK_UCODE_DATA);
     uint32_t data_ptr = *dmem_u32(hle, TASK_DATA_PTR);
 
-    sprintf(&filename[0], "task_%x.log", sum);
+    sprintf(&filename[0], "task_%x.log", uc_start);
     dump_task(hle, filename);
 
     /* dump ucode_boot */
-    sprintf(&filename[0], "ucode_boot_%x.bin", sum);
+    sprintf(&filename[0], "ucode_boot_%x.bin", uc_start);
     dump_binary(hle, filename, (void*)dram_u32(hle, *dmem_u32(hle, TASK_UCODE_BOOT)), *dmem_u32(hle, TASK_UCODE_BOOT_SIZE));
 
     /* dump ucode */
     if (ucode != 0) {
-        sprintf(&filename[0], "ucode_%x.bin", sum);
+        sprintf(&filename[0], "ucode_%x.bin", uc_start);
         dump_binary(hle, filename, (void*)dram_u32(hle, ucode), 0xf80);
     }
 
     /* dump ucode_data */
     if (ucode_data != 0) {
-        sprintf(&filename[0], "ucode_data_%x.bin", sum);
+        sprintf(&filename[0], "ucode_data_%x.bin", uc_start);
         dump_binary(hle, filename, (void*)dram_u32(hle, ucode_data), *dmem_u32(hle, TASK_UCODE_DATA_SIZE));
     }
 
     /* dump data */
     if (data_ptr != 0) {
-        sprintf(&filename[0], "data_%x.bin", sum);
+        sprintf(&filename[0], "data_%x.bin", uc_start);
         dump_binary(hle, filename, (void*)dram_u32(hle, data_ptr), *dmem_u32(hle, TASK_DATA_SIZE));
     }
 }
 
-static void dump_unknown_non_task(struct hle_t* hle, unsigned int sum)
+static void dump_unknown_non_task(struct hle_t* hle, unsigned int uc_start)
 {
     char filename[256];
 
     /* dump IMEM & DMEM for further analysis */
-    sprintf(&filename[0], "imem_%x.bin", sum);
+    sprintf(&filename[0], "imem_%x.bin", uc_start);
     dump_binary(hle, filename, hle->imem, 0x1000);
 
-    sprintf(&filename[0], "dmem_%x.bin", sum);
+    sprintf(&filename[0], "dmem_%x.bin", uc_start);
     dump_binary(hle, filename, hle->dmem, 0x1000);
 }
 

--- a/src/hle_internal.h
+++ b/src/hle_internal.h
@@ -57,12 +57,8 @@ struct hle_t
     /* for user convenience, this will be passed to "external" functions */
     void* user_defined;
 
-    int once_per_rom;
-
     int hle_gfx;
     int hle_aud;
-
-    uint32_t product_code;
 
     /* alist.c */
     uint8_t alist_buffer[0x1000];
@@ -78,6 +74,8 @@ struct hle_t
 
     /* mp3.c */
     uint8_t  mp3_buffer[0x1000];
+
+    struct cached_ucodes_t cached_ucodes;
 };
 
 /* some mips interface interrupt flags */

--- a/src/plugin.c
+++ b/src/plugin.c
@@ -423,28 +423,6 @@ EXPORT m64p_error CALL PluginGetVersion(m64p_plugin_type *PluginType, int *Plugi
 
 EXPORT unsigned int CALL DoRspCycles(unsigned int Cycles)
 {
-    /* Since RSP plugin API doesn't provide a "RomOpen" function
-     * we implement one with a flag inside DoRspCycle.
-     * once_per_rom is reset in RomClose. */
-    if (!g_hle.once_per_rom) {
-
-        /* Extract ROM product code so we can roughly identify ROM */
-        m64p_rom_header rom_header;
-        CoreDoCommand(M64CMD_ROM_GET_HEADER, sizeof(rom_header), &rom_header);
-
-        /* XXX: rom_header structure is WRONG,
-         * so we recompose proper product code from exposed m64p_rom_header */
-        g_hle.product_code
-            = ((uint32_t)rom_header.Manufacturer_ID & UINT32_C(0xff000000))
-            | ((uint32_t)rom_header.Cartridge_ID & UINT32_C(0x00ff)) << 16
-            | ((uint32_t)rom_header.Cartridge_ID & UINT32_C(0xff00))
-            | ((uint32_t)rom_header.Country_code & UINT32_C(0x00ff));
-
-        HleWarnMessage(g_hle.user_defined, "Product Code = %08x", g_hle.product_code);
-
-        g_hle.once_per_rom = 1;
-    }
-
     hle_execute(&g_hle);
     return Cycles;
 }
@@ -483,7 +461,6 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
 
     setup_rsp_fallback(ConfigGetParamString(l_ConfigRspHle, RSP_HLE_CONFIG_FALLBACK));
 
-    g_hle.once_per_rom = 0;
     g_hle.hle_gfx = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_GFX);
     g_hle.hle_aud = ConfigGetParamBool(l_ConfigRspHle, RSP_HLE_CONFIG_HLE_AUD);
 
@@ -495,7 +472,7 @@ EXPORT void CALL InitiateRSP(RSP_INFO Rsp_Info, unsigned int* CycleCount)
 
 EXPORT void CALL RomClosed(void)
 {
-    g_hle.once_per_rom = 0;
+    g_hle.cached_ucodes.count = 0;
 
     /* notify fallback plugin */
     if (l_RomClosed) {

--- a/src/ucodes.h
+++ b/src/ucodes.h
@@ -24,8 +24,23 @@
 
 #include <stdint.h>
 
+#define CACHED_UCODES_MAX_SIZE 16
+
 struct hle_t;
 
+typedef void(*ucode_func_t)(struct hle_t* hle);
+
+struct ucode_info_t {
+    uint32_t     uc_start;
+    uint32_t     uc_dstart;
+    uint16_t     uc_dsize;
+    ucode_func_t uc_pfunc;
+};
+
+struct cached_ucodes_t {
+    struct ucode_info_t infos[CACHED_UCODES_MAX_SIZE];
+    int count;
+};
 
 /* cic_x105 ucode */
 void cicx105_ucode(struct hle_t* hle);


### PR DESCRIPTION
Task dispatching is now only done the first time a ucode is executed.

When a new ucode is executed, following ucode infos are stored in the ```tasks``` list:
- ucode text section address
- ucode data section address
- ucode data size
- function pointer to corresponding ucode function

Next time the ucode is executed, check if the ucode is already in the ```tasks``` list comparing previously stored ucode infos.

If match execute ucode function, otherwise store new ucode infos in the list.
