### PR TITLE
Allow non-default compilers without resorting to symbolic links

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -211,7 +211,7 @@ endif
 endif
 
 # set base program pointers and flags
-CC        = $(CROSS_COMPILE)gcc
+CC       ?= $(CROSS_COMPILE)gcc
 RM       ?= rm -f
 INSTALL  ?= install
 MKDIR ?= mkdir -p


### PR DESCRIPTION
mupen64plus/mupen64plus-core#775