### PR TITLE
Add RISC-V Support

### DIFF
--- a/projects/unix/Makefile
+++ b/projects/unix/Makefile
@@ -130,6 +130,13 @@ ifneq ("$(filter aarch64,$(HOST_CPU))","")
     NEW_DYNAREC := 1
     NO_ASM := 1
 endif
+ifneq ("$(filter riscv64,$(HOST_CPU))","")
+    CPU := RISCV64
+    ARCH_DETECTED := 64BITS
+    PIC ?= 1
+    NO_ASM := 1
+    $(warning Architecture "$(HOST_CPU)" not officially supported.)
+endif
 ifeq ("$(CPU)","NONE")
   $(error CPU type "$(HOST_CPU)" not supported.  Please file bug report at 'https://github.com/mupen64plus/mupen64plus-core/issues')
 endif


### PR DESCRIPTION
Resolves mupen64plus/mupen64plus-core#897 for mupen64plus-rsp-hle

