### PR TITLE
Fix out of bounds memory access encountered in CBFD

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -1017,8 +1017,8 @@ void alist_iirf(
         count -= 0x10;
     } while (count > 0);
 
-    dram_store_u16(hle, (uint16_t*)&frame[6], address + 4, 4);
-    dram_store_u16(hle, (uint16_t*)&ibuf[(index-2)&3], address+8, 2);
-    dram_store_u16(hle, (uint16_t*)&ibuf[(index-1)&3], address+10, 2);
+    dram_store_u16(hle, (uint16_t*)&frame[6], address + 4, 2);
+    dram_store_u16(hle, (uint16_t*)&ibuf[(index-2)&3], address+8, 1);
+    dram_store_u16(hle, (uint16_t*)&ibuf[(index-1)&3], address+10, 1);
 }
 


### PR DESCRIPTION
This is encountered right at startup when Conker is about to cut the N64 logo with the chain saw.

I only detected by using ASAN (https://developer.android.com/ndk/guides/asan).

I tested a few other games and I didn't see or hear any issues, but by inspecting the code, it can immediately be seen that we are copying more data than what we initially copied to ```frame```.