### PR TITLE
Added overload distortion effect, used by a few tracks in CBFD

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -1022,3 +1022,17 @@ void alist_iirf(
     dram_store_u16(hle, (uint16_t*)&ibuf[(index-1)&3], address+10, 1);
 }
 
+/* Perform a clamped gain, then attenuate it back by an amount */
+void alist_overload(struct hle_t* hle, uint16_t dmem, int16_t count, int16_t gain, int16_t attenuation)
+{
+    int16_t accu;
+    int16_t * sample = (int16_t*)(hle->alist_buffer + dmem);
+
+    while (count != 0)
+    {
+        accu = clamp_s16(*sample * gain);
+        *sample = (accu * attenuation) >> 16;
+        sample++;
+        count --;
+    }
+}

--- a/src/alist.c
+++ b/src/alist.c
@@ -1023,7 +1023,7 @@ void alist_iirf(
 }
 
 /* Perform a clamped gain, then attenuate it back by an amount */
-void alist_overload(struct hle_t* hle, uint16_t dmem, int16_t count, int16_t gain, int16_t attenuation)
+void alist_overload(struct hle_t* hle, uint16_t dmem, int16_t count, int16_t gain, uint16_t attenuation)
 {
     int16_t accu;
     int16_t * sample = (int16_t*)(hle->alist_buffer + dmem);

--- a/src/alist.h
+++ b/src/alist.h
@@ -155,7 +155,7 @@ void alist_overload(
         uint16_t dmem,
         int16_t count,
         int16_t gain,
-        int16_t attenuation);
+        uint16_t attenuation);
 
 /*
  * Audio flags

--- a/src/alist.h
+++ b/src/alist.h
@@ -150,6 +150,13 @@ void alist_iirf(
         int16_t* table,
         uint32_t address);
 
+void alist_overload(
+        struct hle_t* hle,
+        uint16_t dmem,
+        int16_t count,
+        int16_t gain,
+        int16_t attenuation);
+
 /*
  * Audio flags
  */

--- a/src/alist_naudio.c
+++ b/src/alist_naudio.c
@@ -263,6 +263,16 @@ static void MP3(struct hle_t* hle, uint32_t w1, uint32_t w2)
     mp3_task(hle, index, address);
 }
 
+static void OVERLOAD(struct hle_t* hle, uint32_t w1, uint32_t w2)
+{
+    /* Overload distortion effect for Conker's Bad Fur Day */
+    uint16_t dmem = (w1 & 0xfff) + NAUDIO_MAIN;
+    int16_t gain = w2 & 0x7fff;
+    int16_t attenuation = w2 >> 16;
+
+    alist_overload(hle, dmem, NAUDIO_COUNT, gain, attenuation);
+}
+
 /* global functions */
 void alist_process_naudio(struct hle_t* hle)
 {
@@ -320,9 +330,8 @@ void alist_process_naudio_mp3(struct hle_t* hle)
 
 void alist_process_naudio_cbfd(struct hle_t* hle)
 {
-    /* TODO: see what differs from alist_process_naudio_mp3 */
     static const acmd_callback_t ABI[0x10] = {
-        UNKNOWN,        ADPCM,          CLEARBUFF,      ENVMIXER,
+        OVERLOAD,       ADPCM,          CLEARBUFF,      ENVMIXER,
         LOADBUFF,       RESAMPLE,       SAVEBUFF,       MP3,
         MP3ADDY,        SETVOL,         DMEMMOVE,       LOADADPCM,
         MIXER,          INTERLEAVE,     NAUDIO_14,      SETLOOP

--- a/src/alist_naudio.c
+++ b/src/alist_naudio.c
@@ -267,8 +267,8 @@ static void OVERLOAD(struct hle_t* hle, uint32_t w1, uint32_t w2)
 {
     /* Overload distortion effect for Conker's Bad Fur Day */
     uint16_t dmem = (w1 & 0xfff) + NAUDIO_MAIN;
-    int16_t gain = w2 & 0x7fff;
-    int16_t attenuation = w2 >> 16;
+    int16_t gain = (int16_t)(uint16_t)w2;
+    uint16_t attenuation = w2 >> 16;
 
     alist_overload(hle, dmem, NAUDIO_COUNT, gain, attenuation);
 }
@@ -318,7 +318,7 @@ void alist_process_naudio_dk(struct hle_t* hle)
 void alist_process_naudio_mp3(struct hle_t* hle)
 {
     static const acmd_callback_t ABI[0x10] = {
-        UNKNOWN,        ADPCM,          CLEARBUFF,      ENVMIXER,
+        OVERLOAD,       ADPCM,          CLEARBUFF,      ENVMIXER,
         LOADBUFF,       RESAMPLE,       SAVEBUFF,       MP3,
         MP3ADDY,        SETVOL,         DMEMMOVE,       LOADADPCM,
         MIXER,          INTERLEAVE,     NAUDIO_14,      SETLOOP

--- a/src/alist_naudio.c
+++ b/src/alist_naudio.c
@@ -330,6 +330,18 @@ void alist_process_naudio_mp3(struct hle_t* hle)
 
 void alist_process_naudio_cbfd(struct hle_t* hle)
 {
+    /* What differs from alist_process_naudio_mp3?
+     *
+     * JoshW: It appears that despite being a newer game, CBFD appears to have a slightly older ucode version
+     * compared to JFG, B.T. et al.
+     * For naudio_mp3, the functions DMEM parameters have an additional protective AND on them
+     * (basically dmem & 0xffff).
+     * But there are minor differences are in the RESAMPLE and ENVMIXER functions.
+     * I don't think it is making any noticeable difference, as it could be just a simplification of the logic.
+     *
+     * bsmiles32: The only difference I could remember between mp3 and cbfd variants is in the MP3ADDY command.
+     * And the MP3 overlay is also different.
+     */
     static const acmd_callback_t ABI[0x10] = {
         OVERLOAD,       ADPCM,          CLEARBUFF,      ENVMIXER,
         LOADBUFF,       RESAMPLE,       SAVEBUFF,       MP3,


### PR DESCRIPTION
This implements a missing audio effect found in CBFD. It can be heard in sparse41, sparse43, and possibly elsewhere. With this change, we are finally able to hear Surf Punks in its full HLE glory. Take a listen:

[sparse41.zip](https://github.com/mupen64plus/mupen64plus-rsp-hle/files/8063193/sparse41.zip)

I haven't checked whether this effect is also present in JFG.

All credits go to @joshware.