### PR TITLE
Fix check for M64P_BIG_ENDIAN

### DIFF
--- a/src/alist.c
+++ b/src/alist.c
@@ -237,7 +237,7 @@ void alist_interleave(struct hle_t* hle, uint16_t dmemo, uint16_t left, uint16_t
         uint16_t r1 = *(srcR++);
         uint16_t r2 = *(srcR++);
 
-#if M64P_BIG_ENDIAN
+#ifdef M64P_BIG_ENDIAN
         *(dst++) = l1;
         *(dst++) = r1;
         *(dst++) = l2;


### PR DESCRIPTION
Every check for M64P_BIG_ENDIAN in the emulator core only checks for its definition, not for its value being non-zero.